### PR TITLE
Interact Goal

### DIFF
--- a/lib/goals.js
+++ b/lib/goals.js
@@ -251,6 +251,79 @@ class GoalFollow extends Goal {
   }
 }
 
+// Moves the bot to a position where it is able to interact with the target
+// block, even from a slight distance. Used to create a more natural approach
+// to interacting and mining without needing to be so close to the target.
+class GoalInteract extends MoveTo {
+  constructor (bot, x, y, z) {
+    super(x, y, z)
+    this.bot = bot
+  }
+
+  isEnd(node)
+  {
+      return this.rayTraceBlock(node);
+  }
+
+  rayTraceBlock(node, maxSteps = 256, vectorLength = 5 / 16) {
+    const height = 1.6; // TODO Check if bot is sneaking at this node
+
+    const start = new Vec3(node.x + 0.5, node.y + height, node.z + 0.5);
+    const end = new Vec3(this.x + 0.5, this.y + 0.5, this.z + 0.5);
+
+    if (start.distanceTo(end) >= 5)
+        return false;
+
+    const step = end.clone().subtract(start).scale(vectorLength);
+    const cursor = start.clone();
+
+    for (let i = 0; i < maxSteps; ++i) {
+        cursor.add(step);
+
+        const block = this.bot.blockAt(cursor);
+        if (!block)
+            continue;
+
+        if (block.position.x === this.x && block.position.y === this.y && block.position.z === this.z)
+            return true;
+
+        if (this.blockObstructsReach(block, node))
+            return false;
+    }
+
+    return false;
+  }
+
+  blockObstructsReach(block, node) {
+      // TODO Check shape of block
+
+      // TODO Support dynamic world changes as a result of handling blocks. (I.e. Water/Sand)
+
+      return !this.getCurrentBoundingBox(block, node);
+  }
+
+  getCurrentBoundingBox(block, node) {
+    const pos = block.position;
+
+    let n = node;
+    while (n) {
+      if (n.toBreak)
+        for (const b of n.toBreak)
+          if (b.x === pos.x && b.y == pos.y && b.z == pos.z)
+            return true;
+
+      if (n.toPlace)
+        for (const b of n.toPlace)
+          if (b.x === pos.x && b.y == pos.y && b.z == pos.z)
+            return false;
+
+      n = n.parent;
+    }
+
+    return block.boundingBox === 'empty';
+  }
+}
+
 function distanceXZ (dx, dz) {
   dx = Math.abs(dx)
   dz = Math.abs(dz)

--- a/movements/main.json
+++ b/movements/main.json
@@ -1,0 +1,24 @@
+{
+	// Cost per block
+	costs: {
+		walk: 1,
+		mine: 2,
+		build: 2,
+		fall: 1,
+		jump: 1
+	},
+
+	maxFallDistance: {
+		standard: 3,
+		withWaterBucket: 64,
+		overSlimeBlock: 128
+	},
+	
+	avoid: [
+		'lava',
+		'wheat'
+	]
+	
+	// In ms
+	timeout: 500
+}

--- a/movements/mining.json
+++ b/movements/mining.json
@@ -1,0 +1,94 @@
+{
+	name: 'miningMovements',
+	movements: [
+		{
+			// mind forward (1 at feet)
+			symetry: 'radial',
+			requires: [
+				{ blockAt: [0, 0, -1], boundingBox: 'solid' },
+				{ blockAt: [0, 1, -1], boundingBox: 'empty', liquid: false },
+				{ blockAt: [0, -1, -1], boundingBox: 'block' },
+			],
+			actions: [
+				{
+					type: 'mine',
+					delta: [0, 0, -1],
+				},
+				{
+					type: 'walk',
+					delta: [0, 0, -1],
+				}
+			]
+		},
+		{
+			// mind forward (1 at head)
+			symetry: 'radial',
+			requires: [
+				{ blockAt: [0, 0, -1], boundingBox: 'empty', liquid: false },
+				{ blockAt: [0, 1, -1], boundingBox: 'block' },
+				{ blockAt: [0, -1, -1], boundingBox: 'block' },
+			],
+			actions: [
+				{
+					type: 'mine',
+					delta: [0, 1, -1],
+				},
+				{
+					type: 'walk',
+					delta: [0, 0, -1],
+				}
+			]
+		},
+		{
+			// mind forward (1x2 path)
+			symetry: 'radial',
+			requires: [
+				{ blockAt: [0, 0, -1], boundingBox: 'block' },
+				{ blockAt: [0, 1, -1], boundingBox: 'block' },
+				{ blockAt: [0, -1, -1], boundingBox: 'block' },
+			],
+			actions: [
+				{
+					type: 'mine',
+					delta: [0, 1, -1],
+				},
+				{
+					type: 'mine',
+					delta: [0, 0, -1],
+				},
+				{
+					type: 'walk',
+					delta: [0, 0, -1],
+				}
+			]
+		},
+		{
+			// mind forward (1x2 path over air)
+			symetry: 'radial',
+			requires: [
+				{ blockAt: [0, 0, -1], boundingBox: 'block' },
+				{ blockAt: [0, 1, -1], boundingBox: 'block' },
+				{ blockAt: [0, -1, -1], boundingBox: 'empty' },
+			],
+			actions: [
+				{
+					type: 'mine',
+					delta: [0, 1, -1],
+				},
+				{
+					type: 'mine',
+					delta: [0, 0, -1],
+				},
+				{
+					type: 'build',
+					delta: [0, -1, -1],
+					against: [0, -1, 0]
+				},
+				{
+					type: 'walk',
+					delta: [0, 0, -1],
+				}
+			]
+		}
+	]
+}

--- a/movements/movements.json
+++ b/movements/movements.json
@@ -1,0 +1,21 @@
+{
+	name: 'basicMovements',
+	movements: [
+		{
+			// move forward
+			cost: 1,
+			symetry: 'radial',
+			requires: [
+				{ blockAt: [0, 0, -1], boundingBox: 'empty', liquid: false },
+				{ blockAt: [0, 1, -1], boundingBox: 'empty', liquid: false },
+				{ blockAt: [0, -1, -1], boundingBox: 'block' },
+			],
+			actions: [
+				{
+					type: 'walk',
+					delta: [0, 0, -1],
+				}
+			]
+		},
+	]
+}


### PR DESCRIPTION
Adds a new goal which puts the bot into a position where it can interact with a target block. This is similar to `GoalGetToBlock`, however, does not require the bot to be near the target block. This allows the bot to interact with blocks from a distance or mine specifc blocks which obstruct it's view to get to the block.

Some examples of valid positions are: (`=` is stone, `B` is bot, `X` is target)
```
==== =
B   X=
B ====
======
```

```
B
B    X
=    =
```

```
X

B
B
=
```

```
B
B X
===
```