### PR TITLE
feat: expose movements and goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/node_modules
+node_modules
 package-lock.json
 yarn.lock
+.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,8 @@ declare module 'mineflayer-pathfinder' {
 
 	export interface Pathfinder {
 		thinkTimeout: number;
+		readonly goal: goals.Goal | null;
+		readonly movements: Movements;
 
 		bestHarvestTool(block: Block): Item | null;
 		getPathTo(

--- a/index.js
+++ b/index.js
@@ -50,6 +50,19 @@ function inject (bot) {
   let thinking = false
   let lastNodeTime = performance.now()
 
+  Object.defineProperties(bot.pathfinder, {
+    goal: {
+      get () {
+        return stateGoal
+      }
+    },
+    movements: {
+      get () {
+        return stateMovements
+      }
+    }
+  })
+
   function resetPath (clearStates = true) {
     path = []
     if (digging) bot.stopDigging()


### PR DESCRIPTION
This PR adds 2 new properties `movements` and `goal`, these are read-only getters

marking as draft until #66 is merged then these can be added to the new typings

resolves #57 