### PR TITLE
Fixed crash with null positions

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -78,7 +78,7 @@ class Movements {
         safe: false,
         physical: false,
         liquid: false,
-        height: pos.y + dy
+        height: dy
       }
     }
     b.safe = b.boundingBox === 'empty' && !this.blocksToAvoid.has(b.type)


### PR DESCRIPTION
This is a partial fix for #53.

In this case, `b` can only be null if `pos` is also null, meaning accessing `pos.y` in this if-statement is never allowed and will always cause a crash.

Assuming `pos.y` is 0 fixes the crash.

While https://github.com/PrismarineJS/mineflayer/issues/1405 needs to be fixed for pathfinding to work correctly, this will at least stop the crashing when dealing with null blocks. Once the skin restorer plugin issue is fixed, #53 can be closed as well.