### PR TITLE
Updated so that it avoids gravel and bedrock

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -36,6 +36,8 @@ class Movements {
     this.blocksToAvoid.add(mcData.blocksByName.fire.id)
     this.blocksToAvoid.add(mcData.blocksByName.wheat.id)
     this.blocksToAvoid.add(mcData.blocksByName.lava.id)
+    this.blocksToAvoid.add(mcData.blocksByName.gravel.id)
+    this.blocksToAvoid.add(mcData.blocksByName.bedrock.id)
 
     this.liquids = new Set()
     this.liquids.add(mcData.blocksByName.water.id)


### PR DESCRIPTION
I thought the bot would avoid bedrock blocks as it's already in the blocksCantBreak set, but I doesn't seem like that. I thought it's better to avoid bedrock because it's unbreakable, so there's no point in pathfinding through it. Also the bot sometimes dies in falling gravel, so I think it's better to avoid gravel, but I'm not sure, some people may want to pathfind to gravel blocks, so I'm not sure about this PR. There is no need to merge it if you don't want.