### PR TITLE
Add ability to navigate through open wooden doors.

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -15,6 +15,44 @@ const diagonalDirections = [
   { x: 1, z: -1 },
   { x: 1, z: 1 }
 ]
+const doorClosedMetadata = [
+  3,  // closed top left south
+  7,  // closed top right south
+  11, // closed bottom left south
+  15, // closed bottom right south
+  19, // closed top left north
+  23, // closed top right north
+  27, // closed bottom left north
+  31, // closed bottom right north
+  35, // closed top left east
+  39, // closed top right east
+  43, // closed bottom left east
+  47, // closed bottom right east
+  51, // closed top left west
+  55, // closed top right west
+  59, // closed bottom left west
+  63, // closed bottom right west
+]
+
+const doorOpenMetadata = [
+  1,  // open top left south
+  5,  // open top right south
+  9,  // open bottom left south
+  13, // open bottom right south
+  17, // open top left north
+  21, // open top right north
+  25, // open bottom left north
+  29, // open bottom right north
+  33, // open top left east
+  37, // open top right east
+  41, // open bottom left east
+  45, // open bottom right east
+  49, // open top left west
+  53, // open top right west
+  57, // open bottom left west
+  61, // open bottom right west
+]
+
 
 class Movements {
   constructor (bot, mcData) {
@@ -94,6 +132,15 @@ class Movements {
     for (const shape of b.shapes) {
       b.height = Math.max(b.height, pos.y + dy + shape[4])
     }
+
+    // check if open door, if so treat it like air so the bot can navigate
+    if (b.name.includes('door') && b.material  === "wood" && doorOpenMetadata.includes(b.metadata)) {
+      b.safe = true
+      b.physical = false
+      b.boundingBox = 'empty'
+      b.diggable = true
+    }
+
     return b
   }
 

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -15,9 +15,14 @@ const diagonalDirections = [
   { x: 1, z: -1 },
   { x: 1, z: 1 }
 ]
+
+/*
+Defines closed door state which could be used
+to create an open closed door action
+
 const doorClosedMetadata = [
-  3,  // closed top left south
-  7,  // closed top right south
+  3, // closed top left south
+  7, // closed top right south
   11, // closed bottom left south
   15, // closed bottom right south
   19, // closed top left north
@@ -31,13 +36,14 @@ const doorClosedMetadata = [
   51, // closed top left west
   55, // closed top right west
   59, // closed bottom left west
-  63, // closed bottom right west
+  63 // closed bottom right west
 ]
+*/
 
 const doorOpenMetadata = [
-  1,  // open top left south
-  5,  // open top right south
-  9,  // open bottom left south
+  1, // open top left south
+  5, // open top right south
+  9, // open bottom left south
   13, // open bottom right south
   17, // open top left north
   21, // open top right north
@@ -50,9 +56,8 @@ const doorOpenMetadata = [
   49, // open top left west
   53, // open top right west
   57, // open bottom left west
-  61, // open bottom right west
+  61 // open bottom right west
 ]
-
 
 class Movements {
   constructor (bot, mcData) {
@@ -134,7 +139,7 @@ class Movements {
     }
 
     // check if open door, if so treat it like air so the bot can navigate
-    if (b.name.includes('door') && b.material  === "wood" && doorOpenMetadata.includes(b.metadata)) {
+    if (b.name.includes('door') && b.material === 'wood' && doorOpenMetadata.includes(b.metadata)) {
       b.safe = true
       b.physical = false
       b.boundingBox = 'empty'


### PR DESCRIPTION
Hi,

This little PR adds the ability to navigate through open wooden doors.  If this is acceptable we were also looking at how the bot could open a door that is closed.

Kind regards,

Nic

Co-Authored-By: Erik Veld <erik.veld@gmail.com>