### PR TITLE
Bot getting stuck in Water fix

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -273,6 +273,7 @@ class Movements {
   }
 
   getMoveUp (node, neighbors) {
+    if (this.getBlock(node, 0, 0, 0).liquid) return
     const block2 = this.getBlock(node, 0, 2, 0)
     let cost = 1 // move cost
     const toBreak = []


### PR DESCRIPTION
Fixes issue #54

The Bot tries to jump up inside the water block to place a Block below it. 
This is not possible with standard Minecraft physics as the player cannot jump high enough out of the water block to place a block below itself. 