### PR TITLE
Legit bot bridging

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function inject (bot) {
   let placing = false
   let placingBlock = null
   let lastNodeTime = performance.now()
+  let returningPos = null
   const physics = new Physics(bot)
 
   bot.pathfinder = {}
@@ -228,10 +229,15 @@ function inject (bot) {
   }
 
   function moveToEdge(block, edge) {
-    //TODO should be replaced with sneak when it is implemented in prismarine-physics
-    const maxMovement = 0.2
     const noneFalloffDistance = .58
-    const targetPos = block.clone().offset(.5, 0, .5).offset(edge.x * noneFalloffDistance, 1, edge.z * noneFalloffDistance)
+    return moveToBlock(block.offset(edge.x * noneFalloffDistance, 1, edge.z * noneFalloffDistance))
+  }
+
+  function moveToBlock(block) {
+    //TODO should be replaced with sneak when it is implemented in prismarine-physics
+    const maxMovement = 0.1
+    const targetPos = block.clone().offset(.5, 0, .5)
+    console.log(targetPos)
     if (bot.entity.position.distanceTo(targetPos) > 0.001) {
       const targetVec = targetPos.clone().subtract(bot.entity.position).normalize()
       if (maxMovement * maxMovement < bot.entity.position.distanceSquared(targetPos)) {
@@ -282,6 +288,11 @@ function inject (bot) {
       bot.emit('path_update', results)
       path = results.path
       astartTimedout = results.status === 'partial'
+    }
+
+    if (returningPos) {
+      if (!moveToBlock(returningPos)) return
+      returningPos = null
     }
 
     if (path.length === 0) {
@@ -341,7 +352,7 @@ function inject (bot) {
         resetPath()
         return
       }
-      if (placingBlock.y === bot.entity.position.floored().y - 1) {
+      if (placingBlock.y === bot.entity.position.floored().y - 1 && placingBlock.dy === 0) {
         if (!moveToEdge(new Vec3(placingBlock.x, placingBlock.y, placingBlock.z), new Vec3(placingBlock.dx, 0, placingBlock.dz))) return
       }
       let canPlace = true
@@ -354,6 +365,7 @@ function inject (bot) {
           const refBlock = bot.blockAt(new Vec3(placingBlock.x, placingBlock.y, placingBlock.z), false)
           bot.placeBlock(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz), function (err) {
             placing = false
+            if (placingBlock.returnPos) returningPos = placingBlock.returnPos.clone()
             lastNodeTime = performance.now()
             if (err) resetPath()
           })

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function inject (bot) {
 
   bot.pathfinder.thinkTimeout = 5000 // ms
   bot.pathfinder.enablePathShortcut = false // disabled by default as it can cause bugs in specific configurations
+  bot.pathfinder.LOSWhenPlacingBlocks = true
 
   bot.pathfinder.bestHarvestTool = (block) => {
     const availableTools = bot.inventory.items()
@@ -324,7 +325,7 @@ function inject (bot) {
       astartTimedout = results.status === 'partial'
     }
 
-    if (returningPos) {
+    if (bot.pathfinder.LOSWhenPlacingBlocks && returningPos) {
       if (!moveToBlock(returningPos)) return
       returningPos = null
     }
@@ -386,7 +387,7 @@ function inject (bot) {
         resetPath()
         return
       }
-      if (placingBlock.y === bot.entity.position.floored().y - 1 && placingBlock.dy === 0) {
+      if (bot.pathfinder.LOSWhenPlacingBlocks && placingBlock.y === bot.entity.position.floored().y - 1 && placingBlock.dy === 0) {
         if (!moveToEdge(new Vec3(placingBlock.x, placingBlock.y, placingBlock.z), new Vec3(placingBlock.dx, 0, placingBlock.dz))) return
       }
       let canPlace = true
@@ -400,7 +401,7 @@ function inject (bot) {
           bot.placeBlock(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz), function (err) {
             bot.setControlState('sneak', false)
             placing = false
-            if (placingBlock.returnPos) returningPos = placingBlock.returnPos.clone()
+            if (bot.LOSWhenPlacingBlocks && placingBlock.returnPos) returningPos = placingBlock.returnPos.clone()
             lastNodeTime = performance.now()
             if (err) resetPath()
           })

--- a/index.js
+++ b/index.js
@@ -216,6 +216,24 @@ function inject (bot) {
     if (Math.abs(bot.entity.position.z - blockZ) > 0.2) { bot.entity.position.z = blockZ }
   }
 
+  function moveToEdge(block, edge) {
+    //TODO should be replaced with sneak when it is implemented in prismarine-physics
+    const maxMovement = 0.2
+    const noneFalloffDistance = .58
+    const targetPos = block.clone().offset(.5, 0, .5).offset(edge.x * noneFalloffDistance, 1, edge.z * noneFalloffDistance)
+    if (bot.entity.position.distanceTo(targetPos) > 0.001) {
+      const targetVec = targetPos.clone().subtract(bot.entity.position).normalize()
+      if (maxMovement * maxMovement < bot.entity.position.distanceSquared(targetPos)) {
+        targetVec.scale(maxMovement)
+      } else {
+        targetVec.scale(bot.entity.position.distanceTo(targetPos))
+      }
+      bot.entity.position.add(targetVec)
+      return false
+    }
+    return true
+  }
+
   bot.on('blockUpdate', (oldBlock, newBlock) => {
     if (isPositionNearPath(oldBlock.position, path) && oldBlock.type !== newBlock.type) {
       resetPath(false)
@@ -309,6 +327,9 @@ function inject (bot) {
       if (!block) {
         resetPath()
         return
+      }
+      if (placingBlock.y === bot.entity.position.floored().y - 1) {
+        if (!moveToEdge(new Vec3(placingBlock.x, placingBlock.y, placingBlock.z), new Vec3(placingBlock.dx, 0, placingBlock.dz))) return
       }
       let canPlace = true
       if (placingBlock.jump) {

--- a/index.js
+++ b/index.js
@@ -272,21 +272,16 @@ function inject (bot) {
     return true
   }
 
-  function moveToBlock(block) {
-    //TODO should be replaced with sneak when it is implemented in prismarine-physics
-    const maxMovement = 0.1
-    const targetPos = block.clone().offset(.5, 0, .5)
-    console.log(targetPos)
-    if (bot.entity.position.distanceTo(targetPos) > 0.001) {
-      const targetVec = targetPos.clone().subtract(bot.entity.position).normalize()
-      if (maxMovement * maxMovement < bot.entity.position.distanceSquared(targetPos)) {
-        targetVec.scale(maxMovement)
-      } else {
-        targetVec.scale(bot.entity.position.distanceTo(targetPos))
-      }
-      bot.entity.position.add(targetVec)
+  function moveToBlock(pos) {
+    // minDistanceSq = Min distance sqrt to the target pos were the bot is centered enough to place blocks around him
+    const minDistanceSq = 0.2 * 0.2
+    const targetPos = pos.clone().offset(.5, 0, .5)
+    if (bot.entity.position.distanceSquared(targetPos) > minDistanceSq) {
+      bot.lookAt(targetPos)
+      bot.setControlState('forward', true)
       return false
     }
+    bot.setControlState('forward', false)
     return true
   }
 

--- a/index.js
+++ b/index.js
@@ -272,10 +272,10 @@ function inject (bot) {
     return true
   }
 
-  function moveToBlock(pos) {
+  function moveToBlock (pos) {
     // minDistanceSq = Min distance sqrt to the target pos were the bot is centered enough to place blocks around him
     const minDistanceSq = 0.2 * 0.2
-    const targetPos = pos.clone().offset(.5, 0, .5)
+    const targetPos = pos.clone().offset(0.5, 0, 0.5)
     if (bot.entity.position.distanceSquared(targetPos) > minDistanceSq) {
       bot.lookAt(targetPos)
       bot.setControlState('forward', true)

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -26,7 +26,7 @@ class Movements {
     this.liquidCost = 1
 
     this.dontCreateFlow = true
-    this.allow1by1towers = true
+    this.allow1by1towers = false
     this.allowFreeMotion = false
     this.allowParkour = true
     this.allowSprinting = true

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -165,7 +165,7 @@ class Movements {
           if (!this.safeToBreak(blockD)) return
           toBreak.push(blockD.position)
         }
-        toPlace.push({ x: node.x, y: node.y - 1, z: node.z, dx: dir.x, dy: 0, dz: dir.z })
+        toPlace.push({ x: node.x, y: node.y - 1, z: node.z, dx: dir.x, dy: 0, dz: dir.z, returnPos : new Vec3(node.x, node.y, node.z )})
         cost += this.placeCost // additional cost for placing a block
       }
 

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -26,7 +26,7 @@ class Movements {
     this.liquidCost = 1
 
     this.dontCreateFlow = true
-    this.allow1by1towers = false
+    this.allow1by1towers = true
     this.allowFreeMotion = false
     this.allowParkour = true
     this.allowSprinting = true

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Returns the best harvest tool in the inventory for the specified block
 
 ### bot.pathfinder.getPathTo(movements, goal, done, timeout)
  * `Returns` - The path
- * `movments` - Movements instance
+ * `movements` - Movements instance
  * `goal` - Goal instance
  * `timeout` - number (optional, default `bot.pathfinder.thinkTimeout`)
 
@@ -87,7 +87,7 @@ Returns the best harvest tool in the inventory for the specified block
  
 ### bot.pathfinder.setMovements(movements)
 Assigns the movements config
- * `movments` - Movements instance
+ * `movements` - Movements instance
 
 ### bot.pathfinder.isMoving()
 A function that checks if the bot is currently moving.


### PR DESCRIPTION
Some anti-cheat plugins don't allow the placing of blocks if the face the block is being placed agains faces await from the current position. This could break the ability for the Bot to build bridges. The bot can now sneak to the edge of the block to place its next block and automatically return to a previous position if the next block to place would be obstructed by the bot.

https://youtu.be/c4Tvc0L0u_0