### PR TITLE
Fixed bug for detect when mining is stopped correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,10 +75,18 @@ function inject (bot) {
     }
   })
 
+  function detectDiggingStopped () {
+    digging = false
+    bot.removeAllListeners('diggingAborted', detectDiggingStopped)
+    bot.removeAllListeners('diggingCompleted', detectDiggingStopped)
+  }
   function resetPath (clearStates = true) {
     path = []
-    if (digging) bot.stopDigging()
-    digging = false
+    if (digging) {
+      bot.stopDigging()
+      bot.on('diggingAborted', detectDiggingStopped)
+      bot.on('diggingCompleted', detectDiggingStopped)
+    }
     placing = false
     pathUpdated = false
     astarContext = null


### PR DESCRIPTION
Hi guys i detect issue with pathfinder.isMining()

When you cancel the pathfinder with 
"bot.pathfinder.setGoal(null)"

The isMining is reset to false instantaly, but this is fake,

if you have any code with 
```js
bot.pathfinder.setGoal(null)
if(pathfinder.isMining() === false)
{
 // all time is enters on code
}
```

In reallity must be wait event is triggered "diggingAborted"

For that i made a event listener to wait until diggingAborted is triggered and then change digging false

On my tests isMining work better, now no have bugs with move + dig 