### PR TITLE
Prevents exceeding Max Listeners when bot dies simultaneously digging

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function inject (bot) {
     astarContext = null
     if (clearStates) bot.clearControlStates()
   }
-
+  bot.on("death", () =>{ bot.removeAllListeners('diggingAborted');  bot.removeAllListeners('diggingCompleted') })
   bot.pathfinder.setGoal = (goal, dynamic = false) => {
     stateGoal = goal
     dynamicGoal = dynamic

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function inject (bot) {
     astarContext = null
     if (clearStates) bot.clearControlStates()
   }
-  bot.on("death", () =>{ bot.removeAllListeners('diggingAborted');  bot.removeAllListeners('diggingCompleted') })
+  bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
   bot.pathfinder.setGoal = (goal, dynamic = false) => {
     stateGoal = goal
     dynamicGoal = dynamic


### PR DESCRIPTION
Prevents MaxListenersExceededWarning _by not exceeding max listeners_ such as from when the bot dies while simultaneously digging  
```js
(node:6948) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 diggingAborted listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:451:17)
    at EventEmitter.addListener (node:events:467:10)
    at resetPath ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:90:11)
    at EventEmitter.<anonymous> ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:294:5)
    at EventEmitter.emit (node:events:376:20)
    at addColumn ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:111:9)
    at Client.<anonymous> ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:327:5)
    at Client.emit (node:events:376:20)
    at FullPacketParser.<anonymous> ({ProjectPath}\node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (node:events:376:20)
(node:6948) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 diggingCompleted listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:451:17)
    at EventEmitter.addListener (node:events:467:10)
    at resetPath ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:91:11)
    at EventEmitter.<anonymous> ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:294:5)
    at EventEmitter.emit (node:events:376:20)
    at addColumn ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:111:9)
    at Client.<anonymous> ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:327:5)
    at Client.emit (node:events:376:20)
    at FullPacketParser.<anonymous> ({ProjectPath}\node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (node:events:376:20)
```
Removing pending listeners on death prevents the stack up of listeners as it would be unlikely the bot will be able to dig in same locations when dead. Therfore not having any MaxListenersExceededWarning from node, also improving performance. 