### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module 'mineflayer-pathfinder' {
 		): ComputedPath;
 		setGoal(goal: goals.Goal, dynamic?: boolean): void;
 		setMovements(movements: Movements): void;
-		goto(goal: goals.Goal, callback: Callback): void;
+		goto(goal: goals.Goal, callback?: Callback): Promise<void>;
 
 		isMoving(): boolean;
 		isMining(): boolean;
@@ -207,5 +207,11 @@ declare module 'mineflayer-pathfinder' {
 		physical: boolean;
 		liquid: boolean;
 		height: number;
+	}
+}
+
+declare module 'mineflayer' {
+	interface Bot {
+		pathfinder: Pathfinder
 	}
 }


### PR DESCRIPTION
bot.pathfinder.goto returns a Promise, and also now you can do bot.pathfinder in TypeScript without getting an error.
