### PR TITLE
Add safeOrBreak check to getMoveDiagonal

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -284,6 +284,8 @@ class Movements {
       neighbors.push(new Move(blockC.position.x, blockC.position.y, blockC.position.z, node.remainingBlocks, cost, toBreak))
     } else if (this.getBlock(node, dir.x, -2, dir.z).physical || blockD.liquid) {
       if (blockC.liquid) return // dont go underwater
+      cost += this.safeOrBreak(blockD, toBreak)
+      if (cost > 100) return
       neighbors.push(new Move(blockC.position.x, blockC.position.y - 1, blockC.position.z, node.remainingBlocks, cost, toBreak))
     }
   }


### PR DESCRIPTION
There are some movements generated that violate the rules because they don't check all the blocks the bot will occupy. For example when a bot moves diagonally and down one block it does not check the final block for safety.

Here is a video demo of the issue: https://youtu.be/0xLNvio0cNA