### PR TITLE
[WIP] Add blocks to not walk on

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -45,6 +45,9 @@ class Movements {
     this.blocksToAvoid.add(mcData.blocksByName.wheat.id)
     this.blocksToAvoid.add(mcData.blocksByName.lava.id)
 
+    this.blocksDontWalk = new Set()
+    this.blocksDontWalk.add(mcData.blocksByName.soul_sand.id)
+
     this.liquids = new Set()
     this.liquids.add(mcData.blocksByName.water.id)
     this.liquids.add(mcData.blocksByName.lava.id)
@@ -121,6 +124,7 @@ class Movements {
     b.replaceable = this.replaceables.has(b.type) && !b.physical
     b.liquid = this.liquids.has(b.type)
     b.height = pos.y + dy
+    b.saveToStep = this.blocksDontWalk.has(b.id)
     for (const shape of b.shapes) {
       b.height = Math.max(b.height, pos.y + dy + shape[4])
     }
@@ -192,6 +196,10 @@ class Movements {
       blockC.height += 1
     }
 
+    if (!blockC.saveToStep) {
+      return
+    }
+
     const block0 = this.getBlock(node, 0, -1, 0)
     if (blockC.height - block0.height > 1.2) return // Too high to jump
 
@@ -223,6 +231,10 @@ class Movements {
       }
       toPlace.push({ x: node.x, y: node.y - 1, z: node.z, dx: dir.x, dy: 0, dz: dir.z })
       cost += this.placeCost // additional cost for placing a block
+    }
+
+    if (blockD.physical && !blockD.saveToStep) {
+      return
     }
 
     cost += this.safeOrBreak(blockB, toBreak)
@@ -264,6 +276,10 @@ class Movements {
       toBreak.push(...toBreak2)
     }
     if (cost > 100) return
+
+    if (!blockC1.saveToStep || !blockC2.saveToStep) {
+      return
+    }
 
     cost += this.safeOrBreak(this.getBlock(node, dir.x, y, dir.z), toBreak)
     if (cost > 100) return
@@ -315,6 +331,10 @@ class Movements {
     const blockLand = this.getLandingBlock(node, dir)
     if (!blockLand) return
 
+    if (!blockLand.saveToStep) {
+      return
+    }
+
     cost += this.safeOrBreak(blockB, toBreak)
     if (cost > 100) return
     cost += this.safeOrBreak(blockC, toBreak)
@@ -336,6 +356,10 @@ class Movements {
 
     const blockLand = this.getLandingBlock(node, { x: 0, z: 0 })
     if (!blockLand) return
+
+    if (!blockLand.saveToStep) {
+      return
+    }
 
     cost += this.safeOrBreak(block0, toBreak)
     if (cost > 100) return
@@ -400,11 +424,11 @@ class Movements {
       const blockC = this.getBlock(node, dx, 0, dz)
       const blockD = this.getBlock(node, dx, -1, dz)
 
-      if (ceilingClear && blockB.safe && blockC.safe && blockD.physical) {
+      if (ceilingClear && blockB.safe && blockC.safe && blockD.physical && blockD.saveToStep) {
         // Forward
         neighbors.push(new Move(blockC.position.x, blockC.position.y, blockC.position.z, node.remainingBlocks, 1, [], [], true))
         break
-      } else if (ceilingClear && blockB.safe && blockC.physical) {
+      } else if (ceilingClear && blockB.safe && blockC.physical && blockD.saveToStep) {
         // Up
         if (blockA.safe) {
           if (blockC.height - block0.height > 1.2) break // Too high to jump
@@ -414,7 +438,7 @@ class Movements {
       } else if ((ceilingClear || d === 2) && blockB.safe && blockC.safe && blockD.safe && floorCleared) {
         // Down
         const blockE = this.getBlock(node, dx, -2, dz)
-        if (blockE.physical) {
+        if (blockE.physical && blockE.saveToStep) {
           neighbors.push(new Move(blockD.position.x, blockD.position.y, blockD.position.z, node.remainingBlocks, 1, [], [], true))
         }
         floorCleared = floorCleared && blockE.safe

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -124,7 +124,7 @@ class Movements {
     b.replaceable = this.replaceables.has(b.type) && !b.physical
     b.liquid = this.liquids.has(b.type)
     b.height = pos.y + dy
-    b.saveToStep = this.blocksDontWalk.has(b.id)
+    b.saveToStep = !this.blocksDontWalk.has(b.type)
     for (const shape of b.shapes) {
       b.height = Math.max(b.height, pos.y + dy + shape[4])
     }
@@ -170,6 +170,10 @@ class Movements {
     const toBreak = []
     const toPlace = []
 
+    if (blockB.physical && !blockB.saveToStep) {
+      return
+    }
+
     if (!blockC.physical) {
       if (node.remainingBlocks === 0) return // not enough blocks to place
 
@@ -194,9 +198,7 @@ class Movements {
       cost += this.placeCost // additional cost for placing a block
 
       blockC.height += 1
-    }
-
-    if (!blockC.saveToStep) {
+    } else if (!blockC.saveToStep) {
       return
     }
 
@@ -231,6 +233,10 @@ class Movements {
       }
       toPlace.push({ x: node.x, y: node.y - 1, z: node.z, dx: dir.x, dy: 0, dz: dir.z })
       cost += this.placeCost // additional cost for placing a block
+    }
+
+    if (blockC.physical && !blockC.saveToStep) {
+      return
     }
 
     if (blockD.physical && !blockD.saveToStep) {
@@ -268,6 +274,10 @@ class Movements {
     cost2 += this.safeOrBreak(blockB2, toBreak2)
     cost2 += this.safeOrBreak(blockC2, toBreak2)
 
+    if (!blockC1.saveToStep || !blockC2.saveToStep || !blockB1.saveToStep || !blockB2.saveToStep) {
+      return
+    }
+
     if (cost1 < cost2) {
       cost += cost1
       toBreak.push(...toBreak1)
@@ -277,10 +287,6 @@ class Movements {
     }
     if (cost > 100) return
 
-    if (!blockC1.saveToStep || !blockC2.saveToStep) {
-      return
-    }
-
     cost += this.safeOrBreak(this.getBlock(node, dir.x, y, dir.z), toBreak)
     if (cost > 100) return
     cost += this.safeOrBreak(this.getBlock(node, dir.x, y + 1, dir.z), toBreak)
@@ -289,6 +295,10 @@ class Movements {
     if (this.getBlock(node, 0, 0, 0).liquid) cost += this.liquidCost
 
     const blockD = this.getBlock(node, dir.x, -1, dir.z)
+    if (blockD.physical && !blockD.saveToStep) {
+      return
+    }
+
     if (y === 1) {
       const block0 = this.getBlock(node, 0, -1, 0)
       if (blockC.height - block0.height > 1.2) return // Too high to jump
@@ -296,9 +306,11 @@ class Movements {
       if (cost > 100) return
       cost += 1
       neighbors.push(new Move(blockC.position.x, blockC.position.y + 1, blockC.position.z, node.remainingBlocks, cost, toBreak))
-    } else if (blockD.physical || blockC.liquid) {
+    } else if (blockD.physical && blockD.saveToStep) {
       neighbors.push(new Move(blockC.position.x, blockC.position.y, blockC.position.z, node.remainingBlocks, cost, toBreak))
-    } else if (this.getBlock(node, dir.x, -2, dir.z).physical || blockD.liquid) {
+    } else if (blockC.liquid) {
+      neighbors.push(new Move(blockC.position.x, blockC.position.y, blockC.position.z, node.remainingBlocks, cost, toBreak))
+    } else if (this.getBlock(node, dir.x, -2, dir.z).physical || blockD.liquid || this.getBlock(node, dir.x, -2, dir.z).saveToStep) {
       if (blockC.liquid) return // dont go underwater
       if (!blockD.safe) return // don't self-immolate
       neighbors.push(new Move(blockC.position.x, blockC.position.y - 1, blockC.position.z, node.remainingBlocks, cost, toBreak))


### PR DESCRIPTION
There is an issue with prismarine-physics were walking speed on soulsand is wrong. Adding a feature were the bot does not walk on certain blocks is also usefull for other things. This is different to blocks to avoid as it can still break the block or build ontop of the block. Im not quite sure if this could be done within block.save so any feedback is welcome. 