### PR TITLE
Fixed raycasting not considering block face

### DIFF
--- a/lib/goals.js
+++ b/lib/goals.js
@@ -310,7 +310,7 @@ class GoalPlaceBlock extends Goal {
 
       const block = this.world.raycast(headPos, dir.normalize(), this.options.range)
 
-      if (block && block.position.equals(ref)) {
+      if (block && block.position.equals(ref) && block.face === vectorToDirection (face.scaled(-1))) {
         return { face, to, ref }
       }
     }

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -276,7 +276,7 @@ class GoalPlaceBlock extends Goal {
     this.world = world
     this.options = options
     if (!this.options.range) this.options.range = 5
-    if (!'LOS' in this.options) this.options.LOS = true
+    if (!('LOS' in this.options)) this.options.LOS = true
     if (!this.options.faces) {
       this.options.faces = [new Vec3(0, -1, 0), new Vec3(0, 1, 0), new Vec3(0, 0, -1), new Vec3(0, 0, 1), new Vec3(-1, 0, 0), new Vec3(1, 0, 0)]
     }

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -311,7 +311,7 @@ class GoalPlaceBlock extends Goal {
       if (!this.checkFacing(dir)) continue
 
       if (!this.options.LOS) {
-        return { face, to, ref}
+        return { face, to, ref }
       }
 
       const block = this.world.raycast(headPos, dir.normalize(), this.options.range)

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -355,7 +355,6 @@ function vectorToDirection (v) {
   } else if (v.x > 0) {
     return 5
   }
-  assert.ok(false, `invalid direction vector ${v}`)
 }
 
 module.exports = {

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -267,6 +267,7 @@ function distanceXZ (dx, dz) {
  * - facing - the direction the player must be facing
  * - facing3D - boolean, facing is 3D (true) or 2D (false)
  * - half - 'top' or 'bottom', the half that must be clicked
+ * - LOS - true or false, should the bot have line of sight off the placement face. Default true.
  */
 class GoalPlaceBlock extends Goal {
   constructor (pos, world, options) {
@@ -275,6 +276,7 @@ class GoalPlaceBlock extends Goal {
     this.world = world
     this.options = options
     if (!this.options.range) this.options.range = 5
+    if (!'LOS' in this.options) this.options.LOS = true
     if (!this.options.faces) {
       this.options.faces = [new Vec3(0, -1, 0), new Vec3(0, 1, 0), new Vec3(0, 0, -1), new Vec3(0, 0, 1), new Vec3(-1, 0, 0), new Vec3(1, 0, 0)]
     }
@@ -310,7 +312,8 @@ class GoalPlaceBlock extends Goal {
 
       const block = this.world.raycast(headPos, dir.normalize(), this.options.range)
 
-      if (block && block.position.equals(ref) && block.face === vectorToDirection(face.scaled(-1))) {
+      if (block && block.position.equals(ref)) {
+        if (this.options.LOS && block.face !== vectorToDirection(face.scaled(-1))) continue
         return { face, to, ref }
       }
     }

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -310,10 +310,12 @@ class GoalPlaceBlock extends Goal {
       if (dir.norm() > this.options.range) continue
       if (!this.checkFacing(dir)) continue
 
-      const block = this.world.raycast(headPos, dir.normalize(), this.options.range)
+      if (!this.options.LOS) {
+        return { face, to, ref}
+      }
 
-      if (block && block.position.equals(ref)) {
-        if (this.options.LOS && block.face !== vectorToDirection(face.scaled(-1))) continue
+      const block = this.world.raycast(headPos, dir.normalize(), this.options.range)
+      if (block && block.position.equals(ref) && block.face !== vectorToDirection(face.scaled(-1))) {
         return { face, to, ref }
       }
     }

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -310,7 +310,7 @@ class GoalPlaceBlock extends Goal {
 
       const block = this.world.raycast(headPos, dir.normalize(), this.options.range)
 
-      if (block && block.position.equals(ref) && block.face === vectorToDirection (face.scaled(-1))) {
+      if (block && block.position.equals(ref) && block.face === vectorToDirection(face.scaled(-1))) {
         return { face, to, ref }
       }
     }
@@ -339,6 +339,23 @@ class GoalPlaceBlock extends Goal {
     const dz = node.z - this.pos.z
     return (Math.abs(dx) + Math.abs(dy < 0 ? dy + 1 : dy) + Math.abs(dz)) < 1
   }
+}
+
+function vectorToDirection (v) {
+  if (v.y < 0) {
+    return 0
+  } else if (v.y > 0) {
+    return 1
+  } else if (v.z < 0) {
+    return 2
+  } else if (v.z > 0) {
+    return 3
+  } else if (v.x < 0) {
+    return 4
+  } else if (v.x > 0) {
+    return 5
+  }
+  assert.ok(false, `invalid direction vector ${v}`)
 }
 
 module.exports = {

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -315,7 +315,7 @@ class GoalPlaceBlock extends Goal {
       }
 
       const block = this.world.raycast(headPos, dir.normalize(), this.options.range)
-      if (block && block.position.equals(ref) && block.face !== vectorToDirection(face.scaled(-1))) {
+      if (block && block.position.equals(ref) && block.face === vectorToDirection(face.scaled(-1))) {
         return { face, to, ref }
       }
     }


### PR DESCRIPTION
GoalPlaceBlock does not check if the raycast opperation hit the right block face when looking for reference blocks to place a block against. This is an issue as anti cheat plugins do raycast calculations on black placement and refuse transactions when the block face is not visible. 