### PR TITLE
Fix place wrong block as scaffolding

### DIFF
--- a/index.js
+++ b/index.js
@@ -394,20 +394,20 @@ function inject (bot) {
         bot.setControlState('jump', true)
         canPlace = placingBlock.y + 1 < bot.entity.position.y
       }
+      bot.equip(block, 'hand', () => {})
+      if (!bot.heldItem || bot.heldItem.type !== block.type) return
       if (canPlace) {
-        bot.equip(block, 'hand', function () {
-          const refBlock = bot.blockAt(new Vec3(placingBlock.x, placingBlock.y, placingBlock.z), false)
-          bot.placeBlock(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz), function (err) {
-            placing = false
-            lastNodeTime = performance.now()
-            if (err) {
-              resetPath('place_error')
-            } else {
-              // Dont release Sneak if the block placement was not successful
-              if (!err) bot.setControlState('sneak', false)
-              if (bot.pathfinder.LOSWhenPlacingBlocks && placingBlock.returnPos) returningPos = placingBlock.returnPos.clone()
-            }
-          })
+        const refBlock = bot.blockAt(new Vec3(placingBlock.x, placingBlock.y, placingBlock.z), false)
+        bot.placeBlock(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz), function (err) {
+          placing = false
+          lastNodeTime = performance.now()
+          if (err) {
+            resetPath('place_error')
+          } else {
+            // Dont release Sneak if the block placement was not successful
+            if (!err) bot.setControlState('sneak', false)
+            if (bot.pathfinder.LOSWhenPlacingBlocks && placingBlock.returnPos) returningPos = placingBlock.returnPos.clone()
+          }
         })
       }
       return


### PR DESCRIPTION
The issue: 
If the last node contains a block to be placed when pathing and you call bot.equip as soon as the goal_reached event is emitted the placed block used as scaffolding can be the wrong block. 

What I tested:
The bot paths so the last block it stands on was placed by placing while jumping. After the goal_reached event has been emitted the bot then places a block by calling bot.equip and bot.placeBlock with a different block to the blocks used in scaffolding. 
In some cases the block placed as scaffolding is the block equiped after goal_reached was emitted. 
In some cases the bot does not place any block as scaffolding but places the block it should after goal_reached is emitted while jumping.

I think this is caused by bot.equip and bot.placeBlock in the monitorMovement function being async. 
Or it might be an edge case with when the bot jump places a block in the last node as it can reach its goal even if it did not place the block it should. 

I dont know if this fixes that issue but it should not equip and place the wrong block.