### PR TITLE
Function to stop path finding when safe

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -81,7 +81,7 @@ bot.once('spawn', () => {
       bot.pathfinder.setMovements(defaultMove)
       bot.pathfinder.setGoal(new GoalInvert(new GoalFollow(target, 5)), true)
     } else if (message === 'stop') {
-      bot.pathfinder.setGoal(null)
+      bot.pathfinder.stop()
     }
   })
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare module 'mineflayer-pathfinder' {
 		setGoal(goal: goals.Goal | null, dynamic?: boolean): void;
 		setMovements(movements: Movements): void;
 		goto(goal: goals.Goal, callback?: Callback): Promise<void>;
+		stop(): void;
 
 		isMoving(): boolean;
 		isMining(): boolean;

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function inject (bot) {
   let placingBlock = null
   let lastNodeTime = performance.now()
   let returningPos = null
+  let stopPathing = false
   const physics = new Physics(bot)
 
   bot.pathfinder = {}
@@ -85,7 +86,7 @@ function inject (bot) {
     bot.removeAllListeners('diggingCompleted', detectDiggingStopped)
   }
   function resetPath (reason, clearStates = true) {
-    if (path.length > 0) bot.emit('path_reset', reason)
+    if (!stopPathing && path.length > 0) bot.emit('path_reset', reason)
     path = []
     if (digging) {
       bot.on('diggingAborted', detectDiggingStopped)
@@ -96,6 +97,7 @@ function inject (bot) {
     pathUpdated = false
     astarContext = null
     if (clearStates) bot.clearControlStates()
+    if (stopPathing) return stop()
   }
 
   bot.pathfinder.setGoal = (goal, dynamic = false) => {
@@ -119,6 +121,10 @@ function inject (bot) {
   }
 
   bot.pathfinder.goto = callbackify(bot.pathfinder.goto, 1)
+
+  bot.pathfinder.stop = () => {
+    stopPathing = true
+  }
 
   bot.on('physicTick', monitorMovement)
 
@@ -285,6 +291,14 @@ function inject (bot) {
     return true
   }
 
+  function stop () {
+    stopPathing = false
+    stateGoal = null
+    path = []
+    bot.emit('path_stop')
+    fullStop()
+  }
+
   bot.on('blockUpdate', (oldBlock, newBlock) => {
     if (isPositionNearPath(oldBlock.position, path) && oldBlock.type !== newBlock.type) {
       resetPath('block_updated', false)
@@ -418,7 +432,12 @@ function inject (bot) {
     let dz = nextPoint.z - p.z
     if (Math.abs(dx) <= 0.35 && Math.abs(dz) <= 0.35 && Math.abs(dy) < 1) {
       // arrived at next point
+      console.log('stop', stopPathing)
       lastNodeTime = performance.now()
+      if (stopPathing) {
+        stop()
+        return
+      }
       path.shift()
       if (path.length === 0) { // done
         if (!dynamicGoal && stateGoal && stateGoal.isEnd(p.floored())) {

--- a/index.js
+++ b/index.js
@@ -432,7 +432,6 @@ function inject (bot) {
     let dz = nextPoint.z - p.z
     if (Math.abs(dx) <= 0.35 && Math.abs(dz) <= 0.35 && Math.abs(dy) < 1) {
       // arrived at next point
-      console.log('stop', stopPathing)
       lastNodeTime = performance.now()
       if (stopPathing) {
         stop()

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,9 @@ Returns the best harvest tool in the inventory for the specified block
 Assigns the movements config
  * `movements` - Movements instance
 
+### bot.pathfinder.stop()
+Stops path finding when its save to stop or after the bot encountered an error while path finding. To force stop use bot.pathfinder.setGoal(null). Emits `path_stop` when stopped.
+
 ### bot.pathfinder.isMoving()
 A function that checks if the bot is currently moving.
  * `Returns` - boolean
@@ -147,6 +150,9 @@ Called when the path is reset, with a reason:
  * `no_scaffolding_blocks`
  * `place_error`
  * `stuck`
+
+ ### path_stop
+ Called when the pathing has been stopped by `bot.pathfinder.stop()`
 
 # Goals:
 


### PR DESCRIPTION
This function is different to `setGoal(null)` as it tries to stop when the bot reaches a safe position. Due to errors while building and bridging it also stops on errors like a placing errors or path resets due to block updates, chunk loading etc. 
When resetting paths the bot cancels its velocity so setGoal(null) can cause the bot to fall off edges or fail jumps.