### PR TITLE
cleanup Pathfinder#goto when Pathfinder#stop is called

### DIFF
--- a/lib/goto.js
+++ b/lib/goto.js
@@ -56,7 +56,7 @@ function goto (bot, goal) {
       }, 0)
     }
 
-    bot.on('path_stop', pathStopped);
+    bot.on('path_stop', pathStopped)
     bot.on('goal_reached', goalReached)
     bot.on('path_update', noPathListener)
     bot.on('goal_updated', goalChangedListener)

--- a/lib/goto.js
+++ b/lib/goto.js
@@ -35,10 +35,15 @@ function goto (bot, goal) {
       }
     }
 
+    function pathStopped () {
+      cleanup()
+    }
+
     function cleanup (err) {
       bot.removeListener('goal_reached', goalReached)
       bot.removeListener('path_update', noPathListener)
       bot.removeListener('goal_updated', goalChangedListener)
+      bot.removeListener('path_stop', pathStopped)
 
       // Run callback on next event stack to let pathfinder properly cleanup,
       // otherwise chaining waypoints does not work properly.
@@ -51,6 +56,7 @@ function goto (bot, goal) {
       }, 0)
     }
 
+    bot.on('path_stop', pathStopped);
     bot.on('goal_reached', goalReached)
     bot.on('path_update', noPathListener)
     bot.on('goal_updated', goalChangedListener)


### PR DESCRIPTION
Calling `Pathfinder#stop` while a path from `Pathfinder#goto` is being travelled causes it to stop indefinitely, making it throw an error when `Pathfinder#goto` is called again.

I've added the `path_stop` listener to `Pathfinder#goto`, which will clean up when called while the path is still being used.