### PR TITLE
Fix compile errors in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,9 +150,9 @@ declare module 'mineflayer-pathfinder' {
 		}
 
 		export class GoalPlaceBlock extends Goal {
-            public heuristic(node: Move): number;
-            public isEnd(node: Move): boolean;
-            public hasChanged(): boolean;
+		public heuristic(node: Move): number;
+		public isEnd(node: Move): boolean;
+		public hasChanged(): boolean;
 			public constructor(pos: Vec3, world: World, options: GoalPlaceBlockOptions)
 		}
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import { Item } from 'prismarine-item';
 import { Vec3 } from 'vec3';
 import { Block } from 'prismarine-block';
 import { Entity } from 'prismarine-entity';
+import { World } from 'prismarine-world'
 
 declare module 'mineflayer-pathfinder' {
 	export function pathfinder(bot: Bot): void;
@@ -149,6 +150,9 @@ declare module 'mineflayer-pathfinder' {
 		}
 
 		export class GoalPlaceBlock extends Goal {
+            public heuristic(node: Move): number;
+            public isEnd(node: Move): boolean;
+            public hasChanged(): boolean;
 			public constructor(pos: Vec3, world: World, options: GoalPlaceBlockOptions)
 		}
 	}
@@ -228,7 +232,7 @@ declare module 'mineflayer-pathfinder' {
 	}
 
 	export interface GoalPlaceBlockOptions {
-		range: int;
+		range: number;
 		LOS: boolean;
 		faces: Vec3[];
 		facing: 'north' | 'east' | 'south' | 'west' | 'up' | 'down';


### PR DESCRIPTION
When compiling other typescript projects with `tsc`  was getting the errors below. Addressing them because it causes tsc to exit nonzero.
```
node_modules/mineflayer-pathfinder/index.d.ts:151:16 - error TS2515: Non-abstract class 'GoalPlaceBlock' does not implement inherited abstract member 'hasChanged' from class 'Goal'.

151   export class GoalPlaceBlock extends Goal {
                   ~~~~~~~~~~~~~~

node_modules/mineflayer-pathfinder/index.d.ts:151:16 - error TS2515: Non-abstract class 'GoalPlaceBlock' does not implement inherited abstract member 'heuristic' from class 'Goal'.

151   export class GoalPlaceBlock extends Goal {
                   ~~~~~~~~~~~~~~

node_modules/mineflayer-pathfinder/index.d.ts:151:16 - error TS2515: Non-abstract class 'GoalPlaceBlock' does not implement inherited abstract member 'isEnd' from class 'Goal'.

151   export class GoalPlaceBlock extends Goal {
                   ~~~~~~~~~~~~~~

node_modules/mineflayer-pathfinder/index.d.ts:152:41 - error TS2304: Cannot find name 'World'.

152    public constructor(pos: Vec3, world: World, options: GoalPlaceBlockOptions)
                                            ~~~~~

node_modules/mineflayer-pathfinder/index.d.ts:230:10 - error TS2304: Cannot find name 'int'.

230   range: int;
             ~~~
```
