### PR TITLE
Fixed reference error when node data is not a vec3

### DIFF
--- a/lib/goals.js
+++ b/lib/goals.js
@@ -323,7 +323,7 @@ class GoalPlaceBlock extends Goal {
 
   isEnd (node) {
     if (this.isStandingIn(node)) return false
-    const headPos = node.offset(0.5, 1.6, 0.5)
+    const headPos = node.constructor?.name === 'Vec3' ? node.offset(0.5, 1.6, 0.5) : new Vec3(node.x, node.y, node.z).offset(0.5, 1.6, 0.5)
     return this.getFaceAndRef(headPos) !== null
   }
 


### PR DESCRIPTION
Should fix #186 
I guess the data of a node can be a none vector. Maybe introduce typings?