### PR TITLE
Fix diagonal move not considering collision height when jumping up diagonally

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -239,22 +239,28 @@ class Movements {
     let cost = Math.SQRT2 // move cost
     const toBreak = []
 
-    const blockC = this.getBlock(node, dir.x, 0, dir.z)
+    const blockC = this.getBlock(node, dir.x, 0, dir.z) // Landing block or standing on block when jumping up by 1
     const y = blockC.physical ? 1 : 0
+
+    const block0 = this.getBlock(node, 0, -1, 0)
 
     let cost1 = 0
     const toBreak1 = []
     const blockB1 = this.getBlock(node, 0, y + 1, dir.z)
     const blockC1 = this.getBlock(node, 0, y, dir.z)
+    const blockD1 = this.getBlock(node, 0, y - 1, dir.z)
     cost1 += this.safeOrBreak(blockB1, toBreak1)
     cost1 += this.safeOrBreak(blockC1, toBreak1)
+    if (blockD1.height - block0.height > 1.2) cost1 += this.safeOrBreak(blockD1, toBreak1)
 
     let cost2 = 0
     const toBreak2 = []
     const blockB2 = this.getBlock(node, dir.x, y + 1, 0)
     const blockC2 = this.getBlock(node, dir.x, y, 0)
+    const blockD2 = this.getBlock(node, dir.x, y - 1, 0)
     cost2 += this.safeOrBreak(blockB2, toBreak2)
     cost2 += this.safeOrBreak(blockC2, toBreak2)
+    if (blockD2.height - block0.height > 1.2) cost2 += this.safeOrBreak(blockD2, toBreak2)
 
     if (cost1 < cost2) {
       cost += cost1
@@ -273,8 +279,7 @@ class Movements {
     if (this.getBlock(node, 0, 0, 0).liquid) cost += this.liquidCost
 
     const blockD = this.getBlock(node, dir.x, -1, dir.z)
-    if (y === 1) {
-      const block0 = this.getBlock(node, 0, -1, 0)
+    if (y === 1) { // Case jump up by 1
       if (blockC.height - block0.height > 1.2) return // Too high to jump
       cost += this.safeOrBreak(this.getBlock(node, 0, 2, 0), toBreak)
       if (cost > 100) return


### PR DESCRIPTION
Fixes the bot getting stuck in this Scenario:
![image](https://user-images.githubusercontent.com/61137113/139594154-ce37f428-af77-45fd-955f-92e7a5dc7994.png)
When moving from the diamond block to the gold block it gets stuck as it tries to jump over the wall even tho it cannot make that jump. By stuck I mean not moving at all as the simulations of the jump fail causing the bot to not move at all.