### PR TITLE
Clarification of GoalBreakBlock

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -156,7 +156,7 @@ declare module 'mineflayer-pathfinder' {
 			public constructor(pos: Vec3, world: World, options: GoalPlaceBlockOptions)
 		}
 		
-		export class GoalBreakBlock extends Goal {
+		export class GoalLookAtBlock  extends Goal {
 			public constructor(x: number, y: number, z: number, bot: Bot, options: Object)
 
 			public x: number;
@@ -168,6 +168,8 @@ declare module 'mineflayer-pathfinder' {
 			public isEnd(node: Move): boolean;
 			public hasChanged(): boolean;
 		}
+
+		export class GoalBreakBlock extends GoalLookAtBlock {}
 	}
 
 	export class Movements {

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -148,7 +148,8 @@ class GoalGetToBlock extends Goal {
   }
 }
 
-class GoalBreakBlock extends Goal {
+// Path into a position were a blockface of block at x y z is visible.
+class GoalLookAtBlock extends Goal {
   constructor (x, y, z, bot, options = {}) {
     super()
     this.x = Math.floor(x)
@@ -198,6 +199,10 @@ class GoalBreakBlock extends Goal {
     return validFaces.length !== 0
   }
 }
+
+// Path into a position were a blockface of block at x y z is visible.
+// You'll manually need to break the block. THIS WONT BREAK IT
+class GoalBreakBlock extends GoalLookAtBlock {}
 
 // A composite of many goals, any one of which satisfies the composite.
 // For example, a GoalCompositeAny of block goals for every oak log in loaded


### PR DESCRIPTION
GoalBreakBlock is misleading. It just looks at a exposed block face.
Additionally, "GoalBreakBlock" is also useful for properly opening chests.

This renames GoalBreakBlock to GoalLookAtBlock, also exposing GoalBreakBlock for backward compatibility.