### PR TITLE
Indicate path stopped to caller

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,7 +157,7 @@ declare module 'mineflayer-pathfinder' {
 		}
 		
 		export class GoalLookAtBlock  extends Goal {
-			public constructor(x: number, y: number, z: number, bot: Bot, options: Object)
+			public constructor(x: number, y: number, z: number, bot: Bot, options?: { reach?: number })
 
 			public x: number;
 			public y: number;

--- a/lib/goto.js
+++ b/lib/goto.js
@@ -36,7 +36,7 @@ function goto (bot, goal) {
     }
 
     function pathStopped () {
-      cleanup()
+      cleanup(error('PathStopped', 'Path was stopped before it could be completed! Thus, the desired goal was not reached.'))
     }
 
     function cleanup (err) {


### PR DESCRIPTION
pathfinder#goto now throws if stopped. 
The path hasn't been completed, and as such, the call should not indicate success.
