### PR TITLE
Refactor GoalLookAtBlock and depricate GoalBreakBlock

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,13 +159,11 @@ declare module 'mineflayer-pathfinder' {
 		}
 		
 		export class GoalLookAtBlock  extends Goal {
-			public constructor(x: number, y: number, z: number, bot: Bot, options?: { reach?: number })
-
-			public x: number;
-			public y: number;
-			public z: number;
+			public constructor(pos: Vec3, world: World, options?: { reach?: number, entityHeight?: number })
 			
-			public bot: Bot;
+			public pos: Vec3
+
+			public world: World;
 			public heuristic(node: Move): number;
 			public isEnd(node: Move): boolean;
 			public hasChanged(): boolean;

--- a/lib/goals.js
+++ b/lib/goals.js
@@ -156,30 +156,28 @@ class GoalGetToBlock extends Goal {
 
 // Path into a position were a blockface of block at x y z is visible.
 class GoalLookAtBlock extends Goal {
-  constructor (x, y, z, bot, options = {}) {
+  constructor (pos, world, options = {}) {
     super()
-    this.x = Math.floor(x)
-    this.y = Math.floor(y)
-    this.z = Math.floor(z)
-    this.bot = bot
-    this.world = bot.world
-    this.reach = options.reach || 4 // default survival: 4.5 creative: 5
+    this.pos = pos
+    this.world = world
+    this.reach = options.reach || 4.5 // default survival: 4.5 creative: 5
+    this.entityHeight = options.entityHeight || 1.6
   }
 
   heuristic (node) {
-    const dx = node.x - this.x
-    const dy = node.y - this.y
-    const dz = node.z - this.z
+    const dx = node.x - this.pos.x
+    const dy = node.y - this.pos.y
+    const dz = node.z - this.pos.z
     return distanceXZ(dx, dz) + Math.abs(dy < 0 ? dy + 1 : dy)
   }
 
   isEnd (node) {
-    if (node.distanceTo(new Vec3(this.x, this.y + this.bot.entity.height, this.z)) > this.reach) return false
+    if (node.distanceTo(this.pos.offset(0, this.entityHeight, 0)) > this.reach) return false
     // Check faces that could be seen from the current position. If the delta is smaller then 0.5 that means the bot cam most likely not see the face as the block is 1 block thick
     // this could be false for blocks that have a smaller bounding box then 1x1x1
-    const dx = node.x - this.x + 0.5
-    const dy = node.y - this.y - 0.5 + this.bot.entity.height // -0.5 because the bot position is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
-    const dz = node.z - this.z + 0.5
+    const dx = node.x - this.pos.x + 0.5
+    const dy = node.y - this.pos.y - 0.5 + this.entityHeight // -0.5 because the bot position is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
+    const dz = node.z - this.pos.z + 0.5
     // Check y first then x and z
     const visibleFaces = {
       y: Math.sign(Math.abs(dy) > 0.5 ? dy : 0),
@@ -192,10 +190,10 @@ class GoalLookAtBlock extends Goal {
         // skip as this face is not visible
         continue
       }
-      const targetPos = new Vec3(this.x, this.y, this.z).offset(0.5 + (i === 'x' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'y' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'z' ? visibleFaces[i] * 0.5 : 0))
-      const startPos = new Vec3(node.x + 0.5, node.y + this.bot.entity.height, node.z + 0.5)
+      const targetPos = new Vec3(this.pos.x, this.pos.y, this.pos.z).offset(0.5 + (i === 'x' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'y' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'z' ? visibleFaces[i] * 0.5 : 0))
+      const startPos = new Vec3(node.x + 0.5, node.y + this.entityHeight, node.z + 0.5)
       const rayPos = this.world.raycast(startPos, targetPos.clone().subtract(startPos).normalize(), this.reach)?.position
-      if (rayPos && rayPos.x === this.x && rayPos.y === this.y && rayPos.z === this.z) {
+      if (rayPos && rayPos.x === this.pos.x && rayPos.y === this.pos.y && rayPos.z === this.pos.z) {
         validFaces.push({
           face: rayPos.face,
           targetPos
@@ -208,7 +206,20 @@ class GoalLookAtBlock extends Goal {
 
 // Path into a position were a blockface of block at x y z is visible.
 // You'll manually need to break the block. THIS WONT BREAK IT
-class GoalBreakBlock extends GoalLookAtBlock {}
+class GoalBreakBlock extends Goal {
+  constructor (x, y, z, bot, options = {}) {
+    super()
+    this.goal = new GoalLookAtBlock(new Vec3(x, y, z), bot, options)
+  }
+
+  isEnd () {
+    return this.goal.isEnd()
+  }
+
+  heuristic (node) {
+    return this.goal.heuristic(node)
+  }
+}
 
 // A composite of many goals, any one of which satisfies the composite.
 // For example, a GoalCompositeAny of block goals for every oak log in loaded
@@ -476,5 +487,6 @@ module.exports = {
   GoalInvert,
   GoalFollow,
   GoalPlaceBlock,
-  GoalBreakBlock
+  GoalBreakBlock,
+  GoalLookAtBlock
 }

--- a/readme.md
+++ b/readme.md
@@ -340,13 +340,21 @@ Follows an entity
 ### GoalPlaceBlock(pos, world, options)
 Position the bot in order to place a block
  * `pos` - Vec3 the position of the placed block
- * `world` - the world of the bot
+ * `world` - the world of the bot (Can be accessed with `bot.world`)
  * `options` - object containing all optionals properties:
    * `range` - maximum distance from the clicked face
    * `faces` - the directions of the faces the player can click
    * `facing` - the direction the player must be facing
    * `facing3D` - boolean, facing is 3D (true) or 2D (false)
    * `half` - `top` or `bottom`, the half that must be clicked
-   
- ### GoalBreakBlock(x, y, z, bot, { range = 5 })
- Path into a position were a blockface of block at x y z is visible. Fourth argument is optional and contains options. `range` option defaults to 4.
+
+ ### GoalLookAtBlock(pos, world, options = {})
+ Path into a position were a blockface of block at pos is visible. Fourth argument is optional and contains extra options.
+  * `pos` - Vec3 the block position to look at
+  * `world` - the world of the bot (Can be accessed with `bot.world`)
+  * `options` - object containing all optionals properties:
+    * `range` - number maximum distance from the clicked face. Default `4.5`
+    * `entityHeight` - number Default is `1.6`
+
+ ### GoalBreakBlock(x, y, z, bot, options)
+ Deprecated. Wrapper for GoalLookAtBlock. Use GoalLookAtBlock instead.


### PR DESCRIPTION
This should make it less confusing when digging and placing blocks. As now both GoalPlaceBlock and GoalLookAtBlock take similar augments.
I also updated the example for placing and breaking blocks. It now includes an example off how to mine blocks.