### PR TITLE
Fix path optimization check

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function inject (bot) {
       }
     }
 
-    if (!bot.pathfinder.enablePathShortcut || stateMovements.exclusionAreasStep.length === 0 || path.length === 0) return path
+    if (!bot.pathfinder.enablePathShortcut || stateMovements.exclusionAreasStep.length !== 0 || path.length === 0) return path
 
     const newPath = []
     let lastNode = bot.entity.position


### PR DESCRIPTION
I think this check is wrong. It should only skip the optimization when exclusionArea is used not when it is not used. This might also be missing exclusionAreaPlace and exclusionAreaBreak but I am 90% sure that that dose not matter anyway as the optimization step cannot introduce any new blocks to break or place.