### PR TITLE
Fix obstructed diagonal movement

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -12,10 +12,10 @@ const cardinalDirections = [
   { x: 0, z: 1 } // South
 ]
 const diagonalDirections = [
-  { x: -1, z: -1, cards: [ 2, 0 ] },
-  { x: -1, z: 1, cards: [ 3, 0 ] },
-  { x: 1, z: -1, cards: [ 1, 2 ] },
-  { x: 1, z: 1, cards: [ 1, 3 ] }
+  { x: -1, z: -1, cards:[ 2, 0 ]},
+  { x: -1, z: 1, cards:[ 3, 0 ]},
+  { x: 1, z: -1, cards:[ 1, 2 ]},
+  { x: 1, z: 1, cards:[ 1, 3 ]}
 ]
 
 class Movements {
@@ -321,8 +321,8 @@ class Movements {
   }
 
   getMoveDiagonal (node, dir, neighbors) {
-    for (let card of dir.cards) {
-      let cardinal = cardinalDirections[card]
+    for (const card of dir.cards) {
+      const cardinal = cardinalDirections[card]
       if (this.getBlock(node, cardinal.x, 0, cardinal.z).physical) {
         return
       }

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -12,10 +12,10 @@ const cardinalDirections = [
   { x: 0, z: 1 } // South
 ]
 const diagonalDirections = [
-  { x: -1, z: -1, cards:[ 2, 0 ]},
-  { x: -1, z: 1, cards:[ 3, 0 ]},
-  { x: 1, z: -1, cards:[ 1, 2 ]},
-  { x: 1, z: 1, cards:[ 1, 3 ]}
+  { x: -1, z: -1, cards: [2, 0] },
+  { x: -1, z: 1, cards: [3, 0] },
+  { x: 1, z: -1, cards: [1, 2] },
+  { x: 1, z: 1, cards: [1, 3] }
 ]
 
 class Movements {

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -12,10 +12,10 @@ const cardinalDirections = [
   { x: 0, z: 1 } // South
 ]
 const diagonalDirections = [
-  { x: -1, z: -1 },
-  { x: -1, z: 1 },
-  { x: 1, z: -1 },
-  { x: 1, z: 1 }
+  { x: -1, z: -1, cards: [ 2, 0 ] },
+  { x: -1, z: 1, cards: [ 3, 0 ] },
+  { x: 1, z: -1, cards: [ 1, 2 ] },
+  { x: 1, z: 1, cards: [ 1, 3 ] }
 ]
 
 class Movements {
@@ -321,9 +321,16 @@ class Movements {
   }
 
   getMoveDiagonal (node, dir, neighbors) {
+    for (let card of dir.cards) {
+      let cardinal = cardinalDirections[card]
+      if (this.getBlock(node, cardinal.x, 0, cardinal.z).physical) {
+        return
+      }
+    }
+    
     let cost = Math.SQRT2 // move cost
     const toBreak = []
-
+    
     const blockC = this.getBlock(node, dir.x, 0, dir.z) // Landing block or standing on block when jumping up by 1
     const y = blockC.physical ? 1 : 0
 

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -327,10 +327,10 @@ class Movements {
         return
       }
     }
-    
+
     let cost = Math.SQRT2 // move cost
     const toBreak = []
-    
+
     const blockC = this.getBlock(node, dir.x, 0, dir.z) // Landing block or standing on block when jumping up by 1
     const y = blockC.physical ? 1 : 0
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -552,7 +552,7 @@ describe('pathfinder Movement', function () {
   })
 
   it('getMoveDiagonal', function () {
-    const dir = new Vec3(1, 0, 0)
+    const dir = { x: 1, z: 0, cards: [0, 0] }
     const neighbors = []
     defaultMovement.getMoveDiagonal(targetBlock, dir, neighbors)
     assert.ok(neighbors.length === 1, `getMoveDiagonal neighbors not right length (${neighbors.length} === 1)`)


### PR DESCRIPTION
When moving diagonally, if there are blocks obstructing the movement, the bot will get stuck forever.

In this example, the red block is the target, the blue block is where the bot is, and the yellow blocks are obstructing the diagonal movement.
![javaw_riiJZcaPA9](https://user-images.githubusercontent.com/26150141/170818329-3bed069f-3eb8-4df6-a414-72b3bb3b0a60.png)

This checks if there are obstructing blocks, and moves around them.