### PR TITLE
Add missing null check

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,6 +330,7 @@ function inject (bot) {
   }
 
   bot.on('blockUpdate', (oldBlock, newBlock) => {
+    if (!oldBlock) return
     if (isPositionNearPath(oldBlock.position, path) && oldBlock.type !== newBlock.type) {
       resetPath('block_updated', false)
     }


### PR DESCRIPTION
`blockUpdate` may fire with `oldBlock` as null causing `isPositionNearPath` to crash