### PR TITLE
Add more goto options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,12 @@ declare module 'mineflayer-pathfinder' {
 
 		setGoal(goal: goals.Goal | null, dynamic?: boolean): void;
 		setMovements(movements: Movements): void;
-		goto(goal: goals.Goal, callback?: Callback): Promise<void>;
+		/**
+		 * @param goal The goal to complete
+		 * @param options goto options. See docs for more info.
+		 * @returns A Promise that resolves once the goal is completed
+		 */
+		goto(goal: goals.Goal, options?: GoToOptions): Promise<void>;
 		stop(): void;
 
 		isMoving(): boolean;
@@ -261,6 +266,15 @@ declare module 'mineflayer-pathfinder' {
 	}
 
 	type Callback = (error?: Error) => void;
+
+	interface GoToOptions {
+		/** setGoal's `dynamic` argument. Defaults to false. */
+		dynamic?: boolean
+		/** If true, the goal will be executed with the best found path. Defaults to false. */
+		allowPartial?: boolean
+		/** Do not reject on `goal_updated` and `path_stop` events. Defaults to false. */
+		silentPathCancel?: boolean
+	}
 
 	interface PathBase {
 		cost: number;

--- a/index.js
+++ b/index.js
@@ -144,8 +144,8 @@ function inject (bot) {
   bot.pathfinder.isMining = () => digging
   bot.pathfinder.isBuilding = () => placing
 
-  bot.pathfinder.goto = (goal) => {
-    return gotoUtil(bot, goal)
+  bot.pathfinder.goto = (goal, options) => {
+    return gotoUtil(bot, goal, options)
   }
 
   bot.pathfinder.stop = () => {

--- a/lib/goto.js
+++ b/lib/goto.js
@@ -11,9 +11,13 @@ function error (name, message) {
    *
    * @param {Bot} bot - The bot.
    * @param {Goal} goal - The goal to execute.
+   * @param { Object } [options={}] options - Optional Options.
+   * @param { boolean } [options.dynamic=false] options.dynamic - setGoal's `dynamic` argument. Defaults to false.
+   * @param { boolean } [options.allowPartial=false] options.allowPartial - If true, the goal will be executed with the best found path. Defaults to false.
+   * @param { boolean } [options.silentPathCancel=false] options.silentPathCancel - Do not reject on `goal_updated` and `path_stop` events. Defaults to false.
    * @returns {Promise} - resolves on success, rejects on error
    */
-function goto (bot, goal) {
+function goto (bot, goal, options = {}) {
   return new Promise((resolve, reject) => {
     function goalReached () {
       cleanup()
@@ -22,21 +26,24 @@ function goto (bot, goal) {
     function noPathListener (results) {
       if (results.path.length === 0) {
         cleanup()
-      } else if (results.status === 'noPath') {
+      } else if (results.status === 'noPath' && !options.allowPartial) {
         cleanup(error('NoPath', 'No path to the goal!'))
-      } else if (results.status === 'timeout') {
+      } else if (results.status === 'timeout' && !options.allowPartial) {
         cleanup(error('Timeout', 'Took to long to decide path to goal!'))
       }
+      cleanup()
     }
 
     function goalChangedListener (newGoal) {
       if (newGoal !== goal) {
-        cleanup(error('GoalChanged', 'The goal was changed before it could be completed!'))
+        if (options.silentPathCancel) cleanup()
+        else cleanup(error('GoalChanged', 'The goal was changed before it could be completed!'))
       }
     }
 
     function pathStopped () {
-      cleanup(error('PathStopped', 'Path was stopped before it could be completed! Thus, the desired goal was not reached.'))
+      if (options.silentPathCancel) cleanup()
+      else cleanup(error('PathStopped', 'Path was stopped before it could be completed! Thus, the desired goal was not reached.'))
     }
 
     function cleanup (err) {
@@ -60,7 +67,7 @@ function goto (bot, goal) {
     bot.on('goal_reached', goalReached)
     bot.on('path_update', noPathListener)
     bot.on('goal_updated', goalChangedListener)
-    bot.pathfinder.setGoal(goal)
+    bot.pathfinder.setGoal(goal, options.dynamic ?? false)
   })
 }
 

--- a/readme.md
+++ b/readme.md
@@ -74,9 +74,13 @@ Also, **for now**, there is only the `pathfinder` module, `movements` and `goals
 
 # Functions:
 
-### bot.pathfinder.goto(goal)
+### bot.pathfinder.goto(goal, options={})
 Returns a Promise with the path result. Resolves when the goal is reached. Rejects on error.
  * `goal` - Goal instance
+ * `options` - Object. Optional.
+   * `dynamic` - Boolean. setGoal's `dynamic` argument. Defaults to false.
+   * `allowPartial` - Boolean. If true, the goal will be executed with the best found path. Defaults to false.
+   * `silentPathCancel` - Boolean. Do not reject on `goal_updated` and `path_stop` events. Defaults to false.
 
 ### bot.pathfinder.bestHarvestTool(block)
 Returns the best harvest tool in the inventory for the specified block


### PR DESCRIPTION
This pr adds some more options to the goto utility. 

Current issue: If the allowPartial option is used and there is no complete path goto won't resolve. This is an issue in pathfinder where it can get stuck with an active goal.