### PR TITLE
Path start fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -203,6 +203,13 @@ declare module 'mineflayer-pathfinder' {
 		public blocksToAvoid: Set<number>;
 		public liquids: Set<number>;
 		public gravityBlocks: Set<number>;
+		public climbables: Set<number>
+		public emptyBlocks: Set<number>
+		public replaceables: Set<number>
+		public fences: Set<number>
+		public carpets: Set<number>
+		public openable: Set<number>
+
 		public scafoldingBlocks: number[];
 
 		public maxDropDown: number;

--- a/index.js
+++ b/index.js
@@ -77,9 +77,11 @@ function inject (bot) {
       start = options.startMove
     } else {
       const p = startPos.floored()
-      const dy = p.y - Math.floor(p.y)
-      const b = bot.blockAt(p)
-      start = new Move(p.x, p.y + (b && dy > 0.001 && bot.entity.onGround && b.type !== 0 ? 1 : 0), p.z, movements.countScaffoldingItems(), 0)
+      const dy = startPos.y - p.y
+      const b = bot.blockAt(p) // The block we are standing in
+      // Offset the floored bot position by one if we are standing on a block that has not the full height but is solid
+      const offset = (b && dy > 0.001 && bot.entity.onGround && !stateMovements.emptyBlocks.has(b.type)) ? 1 : 0
+      start = new Move(p.x, p.y + offset, p.z, movements.countScaffoldingItems(), 0)
     }
     const astarContext = new AStar(start, movements, goal, timeout, tickTimeout, searchRadius)
     let result = astarContext.compute()

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -61,6 +61,7 @@ class Movements {
     this.climbables = new Set()
     this.climbables.add(mcData.blocksByName.ladder.id)
     // this.climbables.add(mcData.blocksByName.vine.id)
+    this.emptyBlocks = new Set()
 
     this.replaceables = new Set()
     this.replaceables.add(mcData.blocksByName.air.id)
@@ -84,6 +85,8 @@ class Movements {
         if (block.shapes[0][4] > 1) this.fences.add(block.type)
         // Carpets or any blocks smaller than 0.1, they will be considered as safe to walk in
         if (block.shapes[0][4] < 0.1) this.carpets.add(block.type)
+      } else if (block.shapes.length === 0) {
+        this.emptyBlocks.add(block.type)
       }
     })
     mcData.blocksArray.forEach(block => {


### PR DESCRIPTION
When starting a path on a none full block the resulting calculations will start inside the block the bot is standing **in** and not the block the bot is standing **on**