### PR TITLE
Change Goal typing and add Goal Documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,8 @@ declare module 'mineflayer-pathfinder' {
 		export abstract class Goal {
 			public abstract heuristic(node: Move): number;
 			public abstract isEnd(node: Move): boolean;
-			public abstract hasChanged(): boolean;
+			public hasChanged(): boolean;
+			public isValid(): boolean;
 		}
 
 		export class GoalBlock extends Goal {

--- a/readme.md
+++ b/readme.md
@@ -318,6 +318,24 @@ Called when the path is reset, with a reason:
 
 # Goals:
 
+### Goal
+Abstract Goal class. Do not instantiate this class. Instead extend it to make a new Goal class.
+
+Has abstract methods:
+ - `heuristic(node)`
+   * `node` - A path node
+   * Returns a heuristic number value for a given node. Must be admissible – meaning that it never overestimates the actual cost to get to the goal.
+ - `isEnd(node)`
+   * `node`
+   * Returns a boolean value if the given node is a end node. 
+
+Implements default methods for:
+ - `isValid()`
+   * Always returns `true`
+ - `hasChanged(node)`
+   * `node` - A path node
+   * Always returns `false`
+
 ### GoalBlock(x, y, z)
 One specific block that the player should stand inside at foot level
  * `x` - Integer


### PR DESCRIPTION
- Add missing isValid method on Goal class
- Make hasChanged none abstract
- Add Goal class documentation

All methods in `Goal` have a default implementation off all methods making re implementing them redundant if they do not change from the default values. `heuristic` and `isEnd` are still abstract as it should be discouraged to make Goal instances that do not implement there own heuristic and isEnd method.