### PR TITLE
Wheat is not an unbreakable block and should not be avoided - but added misleadingly to the two lists

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -41,7 +41,6 @@ class Movements {
 
     this.blocksCantBreak = new Set()
     this.blocksCantBreak.add(registry.blocksByName.chest.id)
-    this.blocksCantBreak.add(registry.blocksByName.wheat.id)
 
     registry.blocksArray.forEach(block => {
       if (block.diggable) return
@@ -50,7 +49,6 @@ class Movements {
 
     this.blocksToAvoid = new Set()
     this.blocksToAvoid.add(registry.blocksByName.fire.id)
-    this.blocksToAvoid.add(registry.blocksByName.wheat.id)
     if (registry.blocksByName.cobweb) this.blocksToAvoid.add(registry.blocksByName.cobweb.id)
     if (registry.blocksByName.web) this.blocksToAvoid.add(registry.blocksByName.web.id)
     this.blocksToAvoid.add(registry.blocksByName.lava.id)

--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,7 @@ Set of blocks (by bot.registry name) that pathfinder should not attempt to place
 * Default - See lib/interactable.json
 
 ### blocksCantBreak
-Set of block id's pathfinder cannot break. Includes chests wheat and all unbreakable blocks.
+Set of block id's pathfinder cannot break. Includes chests and all unbreakable blocks.
 * instance of `Set`
 
 ### blocksToAvoid


### PR DESCRIPTION
Wheat is not an unbreakable block and should not be avoided. There are other crops similar to wheat, such as potatoes or carrots. Farmland (not wheat) may be harmed by jumping rather than by moving. However, categorizing wheat as an unbreakable item is misleading, as it does not require breaking it to pass, moreover, it can be broken if needed. There were issues reported as #102 and #129, and the special handling of wheat (rather than carrot and potato) is still misleading. This issue can be solved in each of the applications by movements.blocksToAvoid.delete(wheat) and movements.blocksCantBreak.delete(wheat), but these default settings cannot be justified, they are confusing and not explicit, it was hard to understand from the documentation why they were implemented and why a bot stuck in wheat.