### PR TITLE
Block face position fix

### DIFF
--- a/lib/goals.js
+++ b/lib/goals.js
@@ -175,9 +175,9 @@ class GoalLookAtBlock extends Goal {
     if (node.distanceTo(this.pos.offset(0, this.entityHeight, 0)) > this.reach) return false
     // Check faces that could be seen from the current position. If the delta is smaller then 0.5 that means the bot cam most likely not see the face as the block is 1 block thick
     // this could be false for blocks that have a smaller bounding box then 1x1x1
-    const dx = node.x - this.pos.x + 0.5
-    const dy = node.y - this.pos.y - 0.5 + this.entityHeight // -0.5 because the bot position is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
-    const dz = node.z - this.pos.z + 0.5
+    const dx = node.x - (this.pos.x + 0.5)
+    const dy = node.y + this.entityHeight - (this.pos.y + 0.5) // -0.5 because the bot position is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
+    const dz = node.z - (this.pos.z + 0.5)
     // Check y first then x and z
     const visibleFaces = {
       y: Math.sign(Math.abs(dy) > 0.5 ? dy : 0),


### PR DESCRIPTION
Same fix I did for mineflayer's visible face math. ([PR](https://github.com/PrismarineJS/mineflayer/pull/2801))

The math for getting the position relative to the center of the block was off by a bit.