### PR TITLE
Added missing constructor definitions for GoalComposite[Any/All] 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,7 @@ declare module 'mineflayer-pathfinder' {
 		}
 
 		export class GoalCompositeAny<T extends Goal> extends Goal {
+			public constructor(goals: T[] = []);
 			public goals: T[];
 			
 			public push(goal: Goal): void;
@@ -135,6 +136,7 @@ declare module 'mineflayer-pathfinder' {
 		}
 
 		export class GoalCompositeAll<T extends Goal> extends Goal {
+			public constructor(goals: T[] = []);
 			public goals: T[];
 
 			public push(goal: Goal): void;


### PR DESCRIPTION
Hey Hey :)

Seems like there were missing typescript deffinitions for ``GoalCompositeAny`` and ``GoalCompositeAll``.
[Look at](https://github.com/PrismarineJS/mineflayer-pathfinder/blob/master/lib/goals.js#L228) and [here](https://github.com/PrismarineJS/mineflayer-pathfinder/blob/master/lib/goals.js#L266).
The doc saying that you can pass array of goals [too](https://github.com/PrismarineJS/mineflayer-pathfinder/blob/master/readme.md?plain=1#L374).

This PR adds missing constructor deffinitions for Typescript. 