### PR TITLE
fix: (spelling) scafold -> scaffold

### DIFF
--- a/examples/movements.js
+++ b/examples/movements.js
@@ -32,7 +32,7 @@ bot.once('spawn', () => {
   // To make changes to the behaviour, customize the properties of the instance
   customMoves.canDig = false
   customMoves.allow1by1towers = false
-  customMoves.scafoldingBlocks.push(bot.registry.itemsByName.stone.id)
+  customMoves.scaffoldingBlocks.push(bot.registry.itemsByName.stone.id)
   // Thing to note scaffoldingBlocks are an array while other namespaces are usually sets
   customMoves.blocksToAvoid.add(bot.registry.blocksByName.carrot.id)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -240,7 +240,7 @@ declare module 'mineflayer-pathfinder' {
 		public carpets: Set<number>
 		public openable: Set<number>
 
-		public scafoldingBlocks: number[];
+		public scaffoldingBlocks: number[];
 
 		public maxDropDown: number;
 		public infiniteLiquidDropdownDistance: boolean;

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -72,9 +72,9 @@ class Movements {
     this.replaceables.add(registry.blocksByName.water.id)
     this.replaceables.add(registry.blocksByName.lava.id)
 
-    this.scafoldingBlocks = []
-    this.scafoldingBlocks.push(registry.itemsByName.dirt.id)
-    this.scafoldingBlocks.push(registry.itemsByName.cobblestone.id)
+    this.scaffoldingBlocks = []
+    this.scaffoldingBlocks.push(registry.itemsByName.dirt.id)
+    this.scaffoldingBlocks.push(registry.itemsByName.cobblestone.id)
 
     const Block = require('prismarine-block')(bot.registry)
     this.fences = new Set()

--- a/lib/movements.js
+++ b/lib/movements.js
@@ -140,7 +140,7 @@ class Movements {
   countScaffoldingItems () {
     let count = 0
     const items = this.bot.inventory.items()
-    for (const id of this.scafoldingBlocks) {
+    for (const id of this.scaffoldingBlocks) {
       for (const j in items) {
         const item = items[j]
         if (item.type === id) count += item.count
@@ -151,7 +151,7 @@ class Movements {
 
   getScaffoldingItem () {
     const items = this.bot.inventory.items()
-    for (const id of this.scafoldingBlocks) {
+    for (const id of this.scaffoldingBlocks) {
       for (const j in items) {
         const item = items[j]
         if (item.type === id) return item

--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,7 @@ bot.once('spawn', () => {
 
   defaultMove.allow1by1towers = false // Do not build 1x1 towers when going up
   defaultMove.canDig = false // Disable breaking of blocks when pathing 
-  defaultMove.scafoldingBlocks.push(bot.registry.itemsByName['netherrack'].id) // Add nether rack to allowed scaffolding items
+  defaultMove.scaffoldingBlocks.push(bot.registry.itemsByName['netherrack'].id) // Add nether rack to allowed scaffolding items
   bot.pathfinder.setMovements(defaultMove) // Update the movement instance pathfinder uses
 
   // Do pathfinder things
@@ -258,7 +258,7 @@ Set of block id's that are climable. Note: Currently unused as pathfinder cannot
 Set of block id's that can be replaced when placing blocks.
 * instance of `Set`
 
-### scafoldingBlocks
+### scaffoldingBlocks
 Array of item id's that can be used as scaffolding blocks.
 * Default - `[<scaffoldingItems>]`
 


### PR DESCRIPTION
There has been a spelling mistake for quite some time in the code project, this pull request aims to resolve the spelling mistake so people can use proper English in their code without confusion.