### PR TITLE
Fix exclusion cost calculation for blockD placement in getMoveJumpUp

### DIFF
--- a/lib/movements.js
+++ b/lib/movements.js
@@ -379,7 +379,7 @@ class Movements {
         cost += this.exclusionBreak(blockD)
         toBreak.push(blockD.position)
       }
-      cost += this.exclusionPlace(blockC)
+      cost += this.exclusionPlace(blockD)
       toPlace.push({ x: node.x, y: node.y - 1, z: node.z, dx: dir.x, dy: 0, dz: dir.z })
       cost += this.placeCost // additional cost for placing a block
     }


### PR DESCRIPTION
## Description
Fixed a bug in `getMoveJumpUp` where the exclusion area cost was calculated for `blockC` instead of `blockD` when placing blocks at the `blockD` position.

## Problem
In line 381 of `lib/movements.js`, when the code is handling the case where `blockD` needs a support block to be placed, it incorrectly calculates the exclusion cost using `blockC`:

```js
cost += this.exclusionPlace(blockC)  // Should be blockD
```

However, the actual placement is at `blockD` position as shown in the `toPlace.push()` call.

## Solution
Changed the exclusion cost calculation to use the correct block:

```js
cost += this.exclusionPlace(blockD)  // Now correctly uses blockD
```

## Impact
This bug could cause incorrect pathfinding decisions, especially when `blockC` and `blockD` positions have different exclusion area costs. The fix ensures that the cost calculation correctly reflects the actual placement location.

## Testing
- [x] Existing tests pass
- [ ] Manual testing shows correct behavior

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update