### PR TITLE
Fixed Vertical Towering Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -563,10 +563,10 @@ function inject (bot) {
                 resetPath('place_error')
               })
               .then(() => {
-                lockPlaceBlock.release()
                 placing = false
                 lastNodeTime = performance.now()
               })
+            lockPlaceBlock.release()
           })
           .catch(_ignoreError => {})
       }


### PR DESCRIPTION
### Bug
When scaffolding vertically, the bot would be unable to place the scaffolding block under it constantly, thus showing an unfavourable behaviour. It was due to the `lockPlaceBlock` being placed nested under `then` of `placeBlock`, thus not releasing the lock when the bot is unable to place a block and `canPlace` is also _true_. This caused the lock to never get released and thus the bot being stuck.
https://github.com/PrismarineJS/mineflayer-pathfinder/blob/874949196ac15a7bca23ac54b403b7a8c8bc71be/index.js#L556-L570

### Fix
Moved the `release` function to a more favourable position outside of `placeBlock` nesting, so that the lock is released continuously after trial of placing the block.

### Test
**Testing Version**- _1.21.8_
Verified by running a simple bot that builds a vertical scaffold to reach a position of y level of 20 above the bot. Builds now perfectly fine.
Also ran the tests provided, and the code passed all of it successfully.


