### PR TITLE
createHuman: walk routes the way players do

### DIFF
--- a/examples/human.js
+++ b/examples/human.js
@@ -1,0 +1,27 @@
+// Walk to whoever says "come" the way a player would: curved steering, mouse-like head turns,
+// sprint after a short delay, coast to a stop, then look at them.
+
+const mineflayer = require('mineflayer')
+const { pathfinder, createHuman } = require('mineflayer-pathfinder')
+const bot = mineflayer.createBot({ username: 'Player' })
+
+bot.loadPlugin(pathfinder)
+
+bot.once('spawn', () => {
+  // The seed fixes this bot's personality (reaction time, sprint delay, jump rate, glances, ...)
+  const human = createHuman(bot, { seed: 42 })
+
+  bot.on('chat', async (username, message) => {
+    if (username === bot.username || message !== 'come') return
+
+    const target = bot.players[username] ? bot.players[username].entity : null
+    if (!target) return bot.chat("I don't see you !")
+
+    try {
+      await human.walkTo(target.position, { faceAt: target.position.offset(0, 1.62, 0) })
+      bot.chat('Hi!')
+    } catch (err) {
+      bot.chat(`Could not get there: ${err.message}`)
+    }
+  })
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,63 @@ import AStar from './lib/astar';
 declare module 'mineflayer-pathfinder' {
 	export function pathfinder(bot: Bot): void;
 
+	/** Walks routes the way a player does: pure-pursuit steering, mouse-like head gestures, human sprint and jump timing. */
+	export function createHuman(bot: Bot, options?: HumanOptions): Human;
+
+	export interface Personality {
+		/** radians, positive is looking down */
+		basePitch: number;
+		/** scales how long one mouse gesture takes (1 = the measured median) */
+		turnTime: number;
+		sprints: boolean;
+		/** seconds between first step and sprint */
+		sprintDelay: number;
+		/** sprint-jumps per second, 0 = never */
+		jumpRate: number;
+		/** pursuit distance in blocks */
+		lookAhead: number;
+		/** release forward this far (plus coast distance) from the goal */
+		stopRadius: number;
+		/** seconds before acting on a new order */
+		reaction: number;
+		/** sideways glances per second while walking, 0 = never */
+		glanceRate: number;
+		/** probability of strafing rather than turning for a 20-60° correction */
+		strafe: number;
+		/** radians of steering error tolerated while walking before the next gesture */
+		deadband: number;
+	}
+
+	export interface HumanOptions {
+		/** the same seed reproduces the same personality and noise */
+		seed?: number;
+		personality?: Partial<Personality>;
+		/** used for planning; default is a walking-only instance (no digging, placing, towers or parkour) */
+		movements?: Movements;
+		/** planning timeout in ms; default bot.pathfinder.thinkTimeout */
+		thinkTimeout?: number;
+	}
+
+	export interface WalkOptions {
+		/** stop within this distance of the goal; default is the personality's stopRadius */
+		radius?: number;
+		/** ms; default 60000 */
+		timeout?: number;
+		/** look at this point once arrived; the walk resolves after the look settles */
+		faceAt?: Vec3;
+	}
+
+	export interface Human {
+		personality: Personality;
+		/** waypoints of the walk in progress, or of the last one */
+		route: Vec3[];
+		/** set to false to suspend the controller without dropping its state */
+		active: boolean;
+		walkTo(goal: Vec3, options?: WalkOptions): Promise<void>;
+		lookAt(point: Vec3, options?: { settleMs?: number }): Promise<void>;
+		stop(): void;
+	}
+
 	export interface Pathfinder {
 		thinkTimeout: number;
 		/** ms, amount of thinking per tick (max 50 ms) */

--- a/index.js
+++ b/index.js
@@ -646,5 +646,6 @@ function inject (bot) {
 module.exports = {
   pathfinder: inject,
   Movements: require('./lib/movements'),
-  goals: require('./lib/goals')
+  goals: require('./lib/goals'),
+  createHuman: require('./lib/human').createHuman
 }

--- a/lib/human.js
+++ b/lib/human.js
@@ -114,7 +114,9 @@ function createHuman (bot, opts = {}) {
   // reaching the goal yields the route to its closest node; the walk fails at that route's end.
   // Waypoints are block centres. A waypoint is dropped only when the segment skipping it is flat, floored
   // under every sample, and clear at feet and head across the body width.
-  async function planRoute (goal) {
+  // `live` is polled between slices: a search whose walk is already gone stops instead of running out its
+  // think timeout, so re-aiming at a moving target cannot pile up searches that all slice the event loop.
+  async function planRoute (goal, live) {
     const goalNode = new GoalBlock(Math.floor(goal.x), Math.floor(goal.y), Math.floor(goal.z))
     const search = bot.pathfinder.getPathFromTo(movements(), bot.entity.position, goalNode, { timeout: opts.thinkTimeout ?? bot.pathfinder.thinkTimeout })
     let res = null
@@ -122,6 +124,7 @@ function createHuman (bot, opts = {}) {
       const step = search.next()
       if (step.value) res = step.value.result
       if (step.done || res.status !== 'partial') break
+      if (live && !live()) return null
       await new Promise(resolve => setImmediate(resolve))
     }
     // A search whose start already satisfies the goal succeeds with an empty path; that is 'already here'.
@@ -345,7 +348,7 @@ function createHuman (bot, opts = {}) {
         return
       }
       w.replanning = true
-      planRoute(w.goal).then(plan => {
+      planRoute(w.goal, () => walk === w).then(plan => {
         w.replanning = false
         if (walk !== w) return
         if (!plan) {
@@ -425,7 +428,7 @@ function createHuman (bot, opts = {}) {
   async function walkTo (goal, o = {}) {
     if (walk) failWalk(walk, new Error('superseded'))
     const seq = ++planSeq
-    const plan = await planRoute(goal)
+    const plan = await planRoute(goal, () => seq === planSeq)
     if (seq !== planSeq) throw new Error('superseded')
     if (!plan) throw new Error(`no path to ${goal}`)
     const { route, complete } = plan

--- a/lib/human.js
+++ b/lib/human.js
@@ -1,0 +1,440 @@
+// Human-like locomotion. The pathfinder plans the route; a per-tick controller decides how it is walked:
+// the head turns with a mouse-like velocity profile, the body steers by pure pursuit along the smoothed
+// route, sprint and sprint-jumps come in with human delays and rates, and the final approach coasts to a
+// stop instead of snapping to the block centre.
+//
+// Calibration targets (48 players recorded walking from a lobby spawn to a row of NPCs, 1.21.4):
+//   head turn per 100 ms while moving: p25 8°, med 14°, p75 24°, p90 44°, p99 107°
+//   head turn per 100 ms while still:  med 20°, p90 354° (snap turns)
+//   first step -> sprint: 25% immediate, med 0.2 s
+//   jumps per second of sprinting: p10 0.4, med 1.0, p90 1.6; pitch: med 10° down (p25 -1°, p75 22°)
+//   motion heading vs head yaw: med 4°, 21% of samples > 25° (strafing / jump landings)
+const { Vec3 } = require('vec3')
+const Movements = require('./movements')
+const goals = require('./goals')
+
+const DEG = Math.PI / 180
+const TICK = 0.05
+// Yaw/pitch change per mouse count at the default 50% sensitivity. Rotations stay on this grid so the
+// deltas share the gcd a real mouse produces.
+const SENS = 0.15 * DEG
+
+// Mulberry32; a seed reproduces one personality and its noise.
+function rng (seed) {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6D2B79F5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function makePersonality (r, over) {
+  const u = (lo, hi) => lo + (hi - lo) * r()
+  const gauss = () => Math.sqrt(-2 * Math.log(1 - r())) * Math.cos(2 * Math.PI * r())
+  const p = {
+    basePitch: Math.min(16, Math.max(-5, 6 + 5 * gauss())) * DEG, // radians, positive is looking down
+    turnTime: u(0.75, 1.3), // scales how long one mouse gesture takes (1 = the measured median)
+    sprints: r() < 0.8,
+    sprintDelay: r() < 0.25 ? 0 : u(0.1, 0.8), // seconds between first step and sprint
+    jumpRate: r() < 0.4 ? 0 : u(0.3, 1.1), // sprint-jumps per second, 0 = never
+    lookAhead: u(1.8, 3.0), // pursuit distance in blocks
+    stopRadius: u(0.25, 0.5), // release forward this far (plus coast distance) from the goal
+    reaction: Math.max(0.08, 0.25 + 0.1 * gauss()), // seconds before acting on a new order
+    glanceRate: r() < 0.35 ? 0 : 1 / u(5, 12), // sideways glances per second while walking, 0 = never
+    strafe: r() < 0.5 ? 0 : u(0.2, 0.6), // probability of strafing rather than turning for a 20-60° correction
+    deadband: u(4, 12) * DEG // radians of steering error tolerated while walking before the next gesture
+  }
+  return { ...p, ...over }
+}
+
+const wrapAngle = (a) => Math.atan2(Math.sin(a), Math.cos(a))
+const quantize = (a) => Math.round(a / SENS) * SENS
+const yawTo = (from, to) => Math.atan2(-(to.x - from.x), -(to.z - from.z))
+const horiz = (v) => Math.hypot(v.x, v.z)
+
+function createHuman (bot, opts = {}) {
+  const r = rng(opts.seed ?? (Date.now() ^ (Math.random() * 2 ** 31)))
+  const personality = makePersonality(r, opts.personality ?? {})
+  if (!bot.pathfinder) bot.loadPlugin(require('../index').pathfinder)
+
+  // Head state, radians, mineflayer convention (yaw = atan2(-dx, -dz), pitch positive up).
+  let yaw = bot.entity?.yaw ?? 0
+  let pitch = bot.entity?.pitch ?? 0
+  let targetYaw = null
+  let targetPitch = null
+  let pitchNoise = 0
+  // One mouse gesture: a minimum-jerk sweep of fixed duration from where the head was to where the
+  // target was when the hand started moving. Between gestures the head does not move at all.
+  let gesture = null
+  let glanceUntil = 0
+  let glanceOffset = 0
+
+  let walk = null
+  let lastRotationDelta = 0
+  let sprintReleaseUntil = 0
+  let jumpHeld = 0
+  let stuckJumpAt = 0
+  let strafeUntil = 0
+  let strafeDir = 'left'
+
+  const human = { personality, route: [], walkTo, lookAt, stop, active: true }
+
+  function movements () {
+    if (opts.movements) return opts.movements
+    const m = new Movements(bot)
+    m.canDig = false
+    m.allow1by1towers = false
+    m.allowParkour = false
+    m.allowSprinting = true
+    m.scafoldingBlocks = []
+    m.maxDropDown = 3
+    return m
+  }
+
+  // Block-centre waypoints from the planner, then string-pulled: a waypoint is dropped when the segment
+  // that skips it is flat, has floor under every sample, and is clear at feet and head for the body width.
+  function planRoute (goal) {
+    const goalNode = new goals.GoalNear(goal.x, goal.y, goal.z, 0.5)
+    const res = bot.pathfinder.getPathTo(movements(), goalNode, opts.thinkTimeout ?? bot.pathfinder.thinkTimeout)
+    if (res.status === 'noPath' || res.path.length === 0) return null
+    const start = bot.entity.position.clone()
+    const pts = [start]
+    for (const m of res.path) {
+      const p = new Vec3(Math.floor(m.x) + 0.5, m.y, Math.floor(m.z) + 0.5)
+      if (p.y === start.y && horiz(p.minus(start)) < 0.8) continue
+      pts.push(p)
+    }
+    pts.push(goal.clone())
+    const out = [pts[0]]
+    let i = 0
+    while (i < pts.length - 1) {
+      let j = pts.length - 1
+      while (j > i + 1 && !straightWalkable(pts[i], pts[j])) j--
+      out.push(pts[j])
+      i = j
+    }
+    return out
+  }
+
+  function solid (p) {
+    const b = bot.blockAt(p)
+    return b != null && b.boundingBox === 'block'
+  }
+
+  function passable (p) {
+    const b = bot.blockAt(p)
+    return b != null && b.boundingBox === 'empty'
+  }
+
+  function straightWalkable (a, b) {
+    if (a.y !== b.y) return false
+    const d = b.minus(a)
+    const len = horiz(d)
+    if (len === 0) return true
+    const nx = -d.z / len
+    const nz = d.x / len
+    const steps = Math.ceil(len / 0.25)
+    for (let s = 0; s <= steps; s++) {
+      const t = s / steps
+      for (const w of [-0.3, 0, 0.3]) {
+        const p = new Vec3(a.x + d.x * t + nx * w, a.y, a.z + d.z * t + nz * w)
+        if (!solid(p.offset(0, -1, 0)) || !passable(p) || !passable(p.offset(0, 1, 0))) return false
+      }
+    }
+    return true
+  }
+
+  // Point on the route `lookAhead` blocks past the bot's projection onto it.
+  function carrot (w, pos) {
+    let remaining = personality.lookAhead
+    let from = pos
+    for (let k = w.idx; k < w.route.length; k++) {
+      const to = w.route[k]
+      const seg = to.minus(from)
+      const len = horiz(seg)
+      if (len >= remaining) {
+        const t = remaining / len
+        return new Vec3(from.x + seg.x * t, to.y, from.z + seg.z * t)
+      }
+      remaining -= len
+      from = to
+    }
+    return w.route[w.route.length - 1]
+  }
+
+  function remainingDistance (w, pos) {
+    let d = 0
+    let from = pos
+    for (let k = w.idx; k < w.route.length; k++) {
+      d += horiz(w.route[k].minus(from))
+      from = w.route[k]
+    }
+    return d
+  }
+
+  function walkDistance (w) {
+    return horiz(w.route[w.route.length - 1].minus(bot.entity.position))
+  }
+
+  // A hand on the mouse only while there is something to do: idle players send no rotation at all.
+  function stepHead (moving) {
+    const ty = targetYaw === null ? yaw : targetYaw + (Date.now() < glanceUntil ? glanceOffset : 0)
+    const tp = targetPitch === null ? pitch : targetPitch + pitchNoise
+    if (gesture === null) {
+      const yawErr = wrapAngle(ty - yaw)
+      const pitchErr = tp - pitch
+      // Precise aiming (a look order, the final approach) tolerates almost nothing; steering while
+      // walking waits until the route has drifted a few degrees off, then corrects in one movement.
+      const tol = walk !== null && targetYaw !== null && !(walk.faceAt && walkDistance(walk) < 2.5) ? personality.deadband : 0.2 * DEG
+      if (Math.abs(yawErr) < tol && Math.abs(pitchErr) < Math.max(tol, 0.2 * DEG)) {
+        lastRotationDelta = 0
+        return
+      }
+      const amp = Math.max(Math.abs(yawErr), Math.abs(pitchErr))
+      // Duration grows with the square root of the amplitude, as hand movements do; snap turns while
+      // standing are quicker than corrections while walking.
+      const secs = (0.08 + 0.3 * Math.sqrt(amp / (90 * DEG))) * (moving ? 1 : 0.6) * personality.turnTime
+      // Each gesture lands a little off its mark, more so for larger turns.
+      const bias = (r() - 0.5) * 0.12 * yawErr
+      gesture = { ticks: 0, total: Math.max(2, Math.round(secs / TICK)), y0: yaw, p0: pitch, ay: yawErr - bias, ap: pitchErr }
+    }
+    const g = gesture
+    g.ticks++
+    const t = Math.min(1, g.ticks / g.total)
+    const frac = t * t * t * (10 - 15 * t + 6 * t * t)
+    yaw = g.y0 + g.ay * frac
+    pitch = Math.max(-89 * DEG, Math.min(89 * DEG, g.p0 + g.ap * frac))
+    if (t >= 1) {
+      gesture = null
+      yaw = wrapAngle(yaw)
+    }
+    // Ornstein-Uhlenbeck drift on pitch while walking: the mouse is never held perfectly still.
+    if (walk) pitchNoise += (-pitchNoise / 2.5) * TICK + 2 * DEG * Math.sqrt(TICK) * (r() * 2 - 1) * 1.7
+    // Hand tremor while the mouse is in motion, below one mouse count most ticks.
+    const jitter = gesture !== null ? 0.08 * DEG : 0
+    const qy = quantize(yaw + (r() - 0.5) * jitter)
+    const qp = quantize(pitch + (r() - 0.5) * jitter)
+    lastRotationDelta = Math.abs(wrapAngle(qy - bot.entity.yaw)) + Math.abs(qp - bot.entity.pitch)
+    if (qy !== bot.entity.yaw || qp !== bot.entity.pitch) bot.look(qy, qp, true)
+  }
+
+  function tick () {
+    if (!human.active || !bot.entity?.position) return
+    const now = Date.now()
+    const pos = bot.entity.position
+    const speed = horiz(bot.entity.velocity)
+    const moving = speed > 0.03
+
+    if (walk) tickWalk(walk, now, pos, speed)
+    stepHead(moving)
+    if (jumpHeld > 0 && --jumpHeld === 0) bot.setControlState('jump', false)
+  }
+
+  function tickWalk (w, now, pos, speed) {
+    if (now - w.startedAt < personality.reaction * 1000) return
+    // Advance past waypoints the bot has reached or walked beyond.
+    while (w.idx < w.route.length - 1) {
+      const wp = w.route[w.idx]
+      const next = w.route[w.idx + 1]
+      const passed = horiz(wp.minus(pos)) < 0.6 ||
+        (wp.y === pos.y && next.minus(wp).dot(pos.minus(wp)) > 0 && horiz(wp.minus(pos)) < 1.2)
+      if (!passed) break
+      w.idx++
+    }
+    const last = w.route[w.route.length - 1]
+    const goalDist = horiz(last.minus(pos))
+    const remaining = remainingDistance(w, pos)
+    if (goalDist < w.bestDist - 0.05) {
+      w.bestDist = goalDist
+      w.lastProgressAt = now
+    }
+
+    // Coast distance: ground friction leaves 0.546 of the horizontal velocity each tick.
+    const coast = speed * 0.546 / (1 - 0.546)
+    const arrived = goalDist <= w.radius + coast && w.idx >= w.route.length - 1
+    if (arrived) {
+      bot.setControlState('forward', false)
+      bot.setControlState('left', false)
+      bot.setControlState('right', false)
+      bot.setControlState('sprint', false)
+      if (speed < 0.02) finishWalk(w)
+      return
+    }
+
+    const target = carrot(w, pos)
+    const wantYaw = yawTo(pos, target)
+    targetYaw = wantYaw
+    targetPitch = -personality.basePitch
+    if (personality.glanceRate > 0 && now > glanceUntil && r() < personality.glanceRate * TICK && remaining > 6) {
+      glanceOffset = (r() < 0.5 ? -1 : 1) * (15 + 25 * r()) * DEG
+      glanceUntil = now + 400 + 500 * r()
+    }
+
+    const err = wrapAngle(wantYaw - yaw)
+    const aerr = Math.abs(err)
+    // Facing far enough off: turn first, as a player does when the target is behind them.
+    const canWalk = aerr < (speed > 0.1 ? 75 : 50) * DEG
+    let left = false
+    let right = false
+    if (canWalk && aerr > 20 * DEG && personality.strafe > 0 && r() < personality.strafe * TICK * 4) {
+      // Strafe holds for a few ticks via the sticky control state below.
+      strafeUntil = now + 250 + 300 * r()
+      strafeDir = err > 0 ? 'left' : 'right'
+    }
+    if (now < strafeUntil && canWalk) {
+      if (strafeDir === 'left') left = true
+      else right = true
+    }
+    bot.setControlState('forward', canWalk)
+    bot.setControlState('left', left)
+    bot.setControlState('right', right)
+    if (canWalk && w.firstStepAt === 0) {
+      w.firstStepAt = now
+      w.sprintAt = now + personality.sprintDelay * 1000
+    }
+
+    const nextUp = w.idx < w.route.length && w.route[w.idx].y > pos.y + 0.5 && horiz(w.route[w.idx].minus(pos)) < 1.1
+    const flatAhead = w.idx < w.route.length && w.route[w.idx].y <= pos.y + 0.5 && horiz(w.route[w.idx].minus(pos)) > 1.5
+    const wantSprint = personality.sprints && canWalk && now >= w.sprintAt && remaining > 2.5 && aerr < 40 * DEG && now > sprintReleaseUntil
+    bot.setControlState('sprint', wantSprint)
+
+    if (bot.entity.onGround && jumpHeld === 0) {
+      if (nextUp) jump()
+      else if (wantSprint && personality.jumpRate > 0 && flatAhead && remaining > 4 && headroom(pos) && r() < personality.jumpRate * TICK / 0.55) jump()
+    }
+
+    // Stuck: no progress for 1.5 s -> hop; 4 s -> re-plan; three re-plans -> give up.
+    if (now - w.lastProgressAt > 1500 && now - stuckJumpAt > 1200 && bot.entity.onGround) {
+      stuckJumpAt = now
+      jump()
+    }
+    if (now - w.lastProgressAt > 4000) {
+      if (++w.replans > 3) {
+        failWalk(w, new Error('stuck'))
+        return
+      }
+      const route = planRoute(w.goal)
+      if (!route) {
+        failWalk(w, new Error('no path on re-plan'))
+        return
+      }
+      w.route = route
+      w.idx = 0
+      w.lastProgressAt = now
+      w.bestDist = Infinity
+      human.route = route
+      sprintReleaseUntil = now + 600
+    }
+  }
+
+  function headroom (pos) {
+    for (let dy = 2; dy <= 3; dy++) if (!passable(pos.offset(0, dy, 0))) return false
+    return true
+  }
+
+  function jump () {
+    bot.setControlState('jump', true)
+    jumpHeld = 1
+  }
+
+  function pitchTo (from, to) {
+    const eye = from.offset(0, bot.entity.eyeHeight ?? 1.62, 0)
+    const d = to.minus(eye)
+    return Math.atan2(d.y, horiz(d))
+  }
+
+  function releaseControls () {
+    for (const c of ['forward', 'back', 'left', 'right', 'sprint', 'jump']) bot.setControlState(c, false)
+  }
+
+  function finishWalk (w) {
+    if (walk !== w) return
+    clearTimeout(w.timer)
+    walk = null
+    releaseControls()
+    if (w.faceAt) {
+      targetYaw = yawTo(bot.entity.position, w.faceAt)
+      targetPitch = pitchTo(bot.entity.position, w.faceAt)
+      settled(400).then(w.resolve, w.resolve)
+    } else {
+      w.resolve()
+    }
+  }
+
+  function failWalk (w, e) {
+    if (walk !== w) return
+    clearTimeout(w.timer)
+    walk = null
+    releaseControls()
+    w.reject(e)
+  }
+
+  // Resolves once the head has stopped moving for `ms`.
+  function settled (ms) {
+    return new Promise(resolve => {
+      let quietSince = Date.now()
+      const check = () => {
+        if (lastRotationDelta > 0.02 * DEG) quietSince = Date.now()
+        if (Date.now() - quietSince >= ms) {
+          bot.off('physicsTick', check)
+          resolve()
+        }
+      }
+      bot.on('physicsTick', check)
+    })
+  }
+
+  function walkTo (goal, o = {}) {
+    if (walk) failWalk(walk, new Error('superseded'))
+    const route = planRoute(goal)
+    if (!route) return Promise.reject(new Error(`no path to ${goal}`))
+    return new Promise((resolve, reject) => {
+      const now = Date.now()
+      const w = {
+        goal: goal.clone(),
+        route, // waypoints, y = feet level
+        idx: 0, // next waypoint
+        radius: o.radius ?? personality.stopRadius,
+        startedAt: now,
+        firstStepAt: 0,
+        lastProgressAt: now + personality.reaction * 1000,
+        bestDist: Infinity,
+        sprintAt: Infinity,
+        faceAt: o.faceAt,
+        replans: 0,
+        resolve,
+        reject,
+        timer: setTimeout(() => failWalk(w, new Error('walk timed out')), o.timeout ?? 60000)
+      }
+      walk = w
+      human.route = route
+    })
+  }
+
+  async function lookAt (point, o = {}) {
+    await new Promise(resolve => setTimeout(resolve, personality.reaction * 1000 * (0.5 + r())))
+    targetYaw = yawTo(bot.entity.position, point)
+    targetPitch = pitchTo(bot.entity.position, point)
+    await settled(o.settleMs ?? 300)
+  }
+
+  function stop () {
+    if (walk) failWalk(walk, new Error('stopped'))
+    targetYaw = null
+    targetPitch = null
+  }
+
+  bot.on('physicsTick', tick)
+  // A server teleport resets the head to whatever the server chose.
+  bot.on('forcedMove', () => {
+    yaw = bot.entity.yaw
+    pitch = bot.entity.pitch
+    gesture = null
+  })
+  return human
+}
+
+module.exports = { createHuman }

--- a/lib/human.js
+++ b/lib/human.js
@@ -394,8 +394,9 @@ function createHuman (bot, opts = {}) {
     if (w.faceAt) {
       targetYaw = yawTo(bot.entity.position, w.faceAt)
       targetPitch = pitchTo(bot.entity.position, w.faceAt)
-      settled(400).then(w.resolve, w.resolve)
+      settled(400).then(releaseHead, releaseHead).then(w.resolve, w.resolve)
     } else {
+      releaseHead()
       w.resolve()
     }
   }
@@ -405,6 +406,7 @@ function createHuman (bot, opts = {}) {
     clearTimeout(w.timer)
     walk = null
     releaseControls()
+    releaseHead()
     w.reject(e)
   }
 
@@ -462,12 +464,19 @@ function createHuman (bot, opts = {}) {
     targetYaw = yawTo(bot.entity.position, point)
     targetPitch = pitchTo(bot.entity.position, point)
     await settled(o.settleMs ?? 300)
+    releaseHead()
+  }
+
+  // The head holds a target only while it is being aimed: once it has arrived, a rotation the
+  // server forces stands instead of being pulled back.
+  function releaseHead () {
+    targetYaw = null
+    targetPitch = null
   }
 
   function stop () {
     if (walk) failWalk(walk, new Error('stopped'))
-    targetYaw = null
-    targetPitch = null
+    releaseHead()
   }
 
   bot.on('physicsTick', tick)

--- a/lib/human.js
+++ b/lib/human.js
@@ -1,7 +1,6 @@
-// Human-like locomotion. The pathfinder plans the route; a per-tick controller decides how it is walked:
-// the head turns with a mouse-like velocity profile, the body steers by pure pursuit along the smoothed
-// route, sprint and sprint-jumps come in with human delays and rates, and the final approach coasts to a
-// stop instead of snapping to the block centre.
+// Player-like locomotion over pathfinder routes. Rotation is sent only inside a mouse gesture, the body
+// follows the string-pulled route by pure pursuit, and a walk ends by coasting, never by a snap to the
+// block centre.
 //
 // Calibration targets (48 players recorded walking from a lobby spawn to a row of NPCs, 1.21.4):
 //   head turn per 100 ms while moving: p25 8°, med 14°, p75 24°, p90 44°, p99 107°
@@ -15,8 +14,7 @@ const goals = require('./goals')
 
 const DEG = Math.PI / 180
 const TICK = 0.05
-// Yaw/pitch change per mouse count at the default 50% sensitivity. Rotations stay on this grid so the
-// deltas share the gcd a real mouse produces.
+// Yaw/pitch per mouse count at the default 50% sensitivity; every rotation sent is a multiple of it.
 const SENS = 0.15 * DEG
 
 // Mulberry32; a seed reproduces one personality and its noise.
@@ -66,8 +64,8 @@ function createHuman (bot, opts = {}) {
   let targetYaw = null
   let targetPitch = null
   let pitchNoise = 0
-  // One mouse gesture: a minimum-jerk sweep of fixed duration from where the head was to where the
-  // target was when the hand started moving. Between gestures the head does not move at all.
+  // A gesture is a fixed-duration minimum-jerk sweep from the head's start to the target's position at
+  // gesture start. The head does not move outside a gesture.
   let gesture = null
   let glanceUntil = 0
   let glanceOffset = 0
@@ -94,12 +92,40 @@ function createHuman (bot, opts = {}) {
     return m
   }
 
-  // Block-centre waypoints from the planner, then string-pulled: a waypoint is dropped when the segment
-  // that skips it is flat, has floor under every sample, and is clear at feet and head for the body width.
-  function planRoute (goal) {
-    const goalNode = new goals.GoalNear(goal.x, goal.y, goal.z, 0.5)
-    const res = bot.pathfinder.getPathTo(movements(), goalNode, opts.thinkTimeout ?? bot.pathfinder.thinkTimeout)
-    if (res.status === 'noPath' || res.path.length === 0) return null
+  // Feet in the goal's block column, within a block of its level.
+  class GoalBlock extends goals.Goal {
+    constructor (x, y, z) {
+      super()
+      this.x = x
+      this.y = y
+      this.z = z
+    }
+
+    heuristic (node) {
+      return Math.hypot(this.x - node.x, this.z - node.z) + Math.abs(this.y - node.y)
+    }
+
+    isEnd (node) {
+      return node.x === this.x && node.z === this.z && Math.abs(node.y - this.y) <= 1
+    }
+  }
+
+  // Each search slice holds the event loop for at most one tick's thinking. A search that ends without
+  // reaching the goal yields the route to its closest node; the walk fails at that route's end.
+  // Waypoints are block centres. A waypoint is dropped only when the segment skipping it is flat, floored
+  // under every sample, and clear at feet and head across the body width.
+  async function planRoute (goal) {
+    const goalNode = new GoalBlock(Math.floor(goal.x), Math.floor(goal.y), Math.floor(goal.z))
+    const search = bot.pathfinder.getPathFromTo(movements(), bot.entity.position, goalNode, { timeout: opts.thinkTimeout ?? bot.pathfinder.thinkTimeout })
+    let res = null
+    for (;;) {
+      const step = search.next()
+      if (step.value) res = step.value.result
+      if (step.done || res.status !== 'partial') break
+      await new Promise(resolve => setImmediate(resolve))
+    }
+    if (res === null || res.path.length === 0) return null
+    const complete = res.status === 'success'
     const start = bot.entity.position.clone()
     const pts = [start]
     for (const m of res.path) {
@@ -107,7 +133,7 @@ function createHuman (bot, opts = {}) {
       if (p.y === start.y && horiz(p.minus(start)) < 0.8) continue
       pts.push(p)
     }
-    pts.push(goal.clone())
+    if (complete) pts.push(goal.clone())
     const out = [pts[0]]
     let i = 0
     while (i < pts.length - 1) {
@@ -116,7 +142,7 @@ function createHuman (bot, opts = {}) {
       out.push(pts[j])
       i = j
     }
-    return out
+    return { route: out, complete }
   }
 
   function solid (p) {
@@ -179,25 +205,23 @@ function createHuman (bot, opts = {}) {
     return horiz(w.route[w.route.length - 1].minus(bot.entity.position))
   }
 
-  // A hand on the mouse only while there is something to do: idle players send no rotation at all.
+  // No rotation is sent while there is no target.
   function stepHead (moving) {
     const ty = targetYaw === null ? yaw : targetYaw + (Date.now() < glanceUntil ? glanceOffset : 0)
     const tp = targetPitch === null ? pitch : targetPitch + pitchNoise
     if (gesture === null) {
       const yawErr = wrapAngle(ty - yaw)
       const pitchErr = tp - pitch
-      // Precise aiming (a look order, the final approach) tolerates almost nothing; steering while
-      // walking waits until the route has drifted a few degrees off, then corrects in one movement.
+      // A look order and the final approach tolerate 0.2°; steering while walking tolerates `deadband`.
       const tol = walk !== null && targetYaw !== null && !(walk.faceAt && walkDistance(walk) < 2.5) ? personality.deadband : 0.2 * DEG
       if (Math.abs(yawErr) < tol && Math.abs(pitchErr) < Math.max(tol, 0.2 * DEG)) {
         lastRotationDelta = 0
         return
       }
       const amp = Math.max(Math.abs(yawErr), Math.abs(pitchErr))
-      // Duration grows with the square root of the amplitude, as hand movements do; snap turns while
-      // standing are quicker than corrections while walking.
+      // Duration grows with the square root of the amplitude; a standing turn takes 0.6x a walking one.
       const secs = (0.08 + 0.3 * Math.sqrt(amp / (90 * DEG))) * (moving ? 1 : 0.6) * personality.turnTime
-      // Each gesture lands a little off its mark, more so for larger turns.
+      // A gesture lands up to 6% of its yaw off the mark.
       const bias = (r() - 0.5) * 0.12 * yawErr
       gesture = { ticks: 0, total: Math.max(2, Math.round(secs / TICK)), y0: yaw, p0: pitch, ay: yawErr - bias, ap: pitchErr }
     }
@@ -211,9 +235,9 @@ function createHuman (bot, opts = {}) {
       gesture = null
       yaw = wrapAngle(yaw)
     }
-    // Ornstein-Uhlenbeck drift on pitch while walking: the mouse is never held perfectly still.
+    // Ornstein-Uhlenbeck pitch noise applies only while walking.
     if (walk) pitchNoise += (-pitchNoise / 2.5) * TICK + 2 * DEG * Math.sqrt(TICK) * (r() * 2 - 1) * 1.7
-    // Hand tremor while the mouse is in motion, below one mouse count most ticks.
+    // Jitter applies only during a gesture and stays below one mouse count most ticks.
     const jitter = gesture !== null ? 0.08 * DEG : 0
     const qy = quantize(yaw + (r() - 0.5) * jitter)
     const qp = quantize(pitch + (r() - 0.5) * jitter)
@@ -235,7 +259,7 @@ function createHuman (bot, opts = {}) {
 
   function tickWalk (w, now, pos, speed) {
     if (now - w.startedAt < personality.reaction * 1000) return
-    // Advance past waypoints the bot has reached or walked beyond.
+    // A waypoint is passed within 0.6 blocks, or within 1.2 blocks once the bot is beyond it along the next segment.
     while (w.idx < w.route.length - 1) {
       const wp = w.route[w.idx]
       const next = w.route[w.idx + 1]
@@ -260,7 +284,10 @@ function createHuman (bot, opts = {}) {
       bot.setControlState('left', false)
       bot.setControlState('right', false)
       bot.setControlState('sprint', false)
-      if (speed < 0.02) finishWalk(w)
+      if (speed < 0.02) {
+        if (w.complete || horiz(w.goal.minus(pos)) <= w.radius + 1) finishWalk(w)
+        else failWalk(w, new Error(`no path to ${w.goal}`))
+      }
       return
     }
 
@@ -275,12 +302,12 @@ function createHuman (bot, opts = {}) {
 
     const err = wrapAngle(wantYaw - yaw)
     const aerr = Math.abs(err)
-    // Facing far enough off: turn first, as a player does when the target is behind them.
+    // Forward is held only while the heading error is under 50° (75° while moving).
     const canWalk = aerr < (speed > 0.1 ? 75 : 50) * DEG
     let left = false
     let right = false
     if (canWalk && aerr > 20 * DEG && personality.strafe > 0 && r() < personality.strafe * TICK * 4) {
-      // Strafe holds for a few ticks via the sticky control state below.
+      // A strafe holds for 250-550 ms through strafeUntil.
       strafeUntil = now + 250 + 300 * r()
       strafeDir = err > 0 ? 'left' : 'right'
     }
@@ -306,27 +333,32 @@ function createHuman (bot, opts = {}) {
       else if (wantSprint && personality.jumpRate > 0 && flatAhead && remaining > 4 && headroom(pos) && r() < personality.jumpRate * TICK / 0.55) jump()
     }
 
-    // Stuck: no progress for 1.5 s -> hop; 4 s -> re-plan; three re-plans -> give up.
+    // No progress for 1.5 s hops; 4 s re-plans, one in flight at a time; more than three re-plans fails the walk.
     if (now - w.lastProgressAt > 1500 && now - stuckJumpAt > 1200 && bot.entity.onGround) {
       stuckJumpAt = now
       jump()
     }
-    if (now - w.lastProgressAt > 4000) {
+    if (now - w.lastProgressAt > 4000 && !w.replanning) {
       if (++w.replans > 3) {
         failWalk(w, new Error('stuck'))
         return
       }
-      const route = planRoute(w.goal)
-      if (!route) {
-        failWalk(w, new Error('no path on re-plan'))
-        return
-      }
-      w.route = route
-      w.idx = 0
-      w.lastProgressAt = now
-      w.bestDist = Infinity
-      human.route = route
-      sprintReleaseUntil = now + 600
+      w.replanning = true
+      planRoute(w.goal).then(plan => {
+        w.replanning = false
+        if (walk !== w) return
+        if (!plan) {
+          failWalk(w, new Error('no path on re-plan'))
+          return
+        }
+        w.route = plan.route
+        w.complete = plan.complete
+        w.idx = 0
+        w.lastProgressAt = Date.now()
+        w.bestDist = Infinity
+        human.route = plan.route
+        sprintReleaseUntil = Date.now() + 600
+      })
     }
   }
 
@@ -387,16 +419,23 @@ function createHuman (bot, opts = {}) {
     })
   }
 
-  function walkTo (goal, o = {}) {
+  let planSeq = 0
+
+  async function walkTo (goal, o = {}) {
     if (walk) failWalk(walk, new Error('superseded'))
-    const route = planRoute(goal)
-    if (!route) return Promise.reject(new Error(`no path to ${goal}`))
+    const seq = ++planSeq
+    const plan = await planRoute(goal)
+    if (seq !== planSeq) throw new Error('superseded')
+    if (!plan) throw new Error(`no path to ${goal}`)
+    const { route, complete } = plan
     return new Promise((resolve, reject) => {
       const now = Date.now()
       const w = {
         goal: goal.clone(),
         route, // waypoints, y = feet level
         idx: 0, // next waypoint
+        complete, // the route ends at the goal rather than at the closest reachable point
+        replanning: false,
         radius: o.radius ?? personality.stopRadius,
         startedAt: now,
         firstStepAt: 0,
@@ -428,7 +467,7 @@ function createHuman (bot, opts = {}) {
   }
 
   bot.on('physicsTick', tick)
-  // A server teleport resets the head to whatever the server chose.
+  // A server teleport sets the head to the entity's rotation and cancels the gesture.
   bot.on('forcedMove', () => {
     yaw = bot.entity.yaw
     pitch = bot.entity.pitch

--- a/lib/human.js
+++ b/lib/human.js
@@ -124,7 +124,8 @@ function createHuman (bot, opts = {}) {
       if (step.done || res.status !== 'partial') break
       await new Promise(resolve => setImmediate(resolve))
     }
-    if (res === null || res.path.length === 0) return null
+    // A search whose start already satisfies the goal succeeds with an empty path; that is 'already here'.
+    if (res === null || (res.path.length === 0 && res.status !== 'success')) return null
     const complete = res.status === 'success'
     const start = bot.entity.position.clone()
     const pts = [start]

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,49 @@ How many milliseconds per tick are allocated to thinking.
 The search limiting radius, in blocks, if `-1` the search is not limited by distance.
  * `Default` - `-1`
 
+# Human-like walking
+
+`createHuman(bot, options)` returns a controller that walks routes the way a player does. The pathfinder only plans the route; the controller then follows it by pure pursuit (corners become curves, the bot never snaps to block centres), turns the head in discrete mouse-like gestures on the 0.15° sensitivity grid, starts sprinting and sprint-jumping with human delays and rates, and coasts to a stop at the goal instead of braking on it. Reaction time, base pitch, glances and strafing are per-bot personality traits drawn from a seed. It walks, steps up single blocks and drops down; it does not dig, place, swim or parkour.
+
+```js
+const { createHuman } = require('mineflayer-pathfinder')
+
+const human = createHuman(bot, { seed: 42 })
+await human.walkTo(new Vec3(10.5, 64, -20.5), { faceAt: npc.position.offset(0, 1.62, 0) })
+```
+
+### createHuman(bot, options)
+ * `bot` - the bot; the pathfinder plugin is loaded if it is not yet
+ * `options` - optional:
+   * `seed` - number; the same seed reproduces the same personality and noise
+   * `personality` - overrides for any trait listed under `human.personality`
+   * `movements` - Movements instance used for planning (default: a walking-only instance that does not dig, place, tower or parkour)
+   * `thinkTimeout` - planning timeout in ms (default: `bot.pathfinder.thinkTimeout`)
+ * `Returns` - a `Human`
+
+### human.walkTo(goal, options)
+Walks to `goal` (a Vec3 at feet level) and returns a Promise that resolves once the bot has come to a stop there. Rejects with `no path`, `stuck`, `walk timed out`, `superseded` (a newer `walkTo` was issued) or `stopped`.
+ * `options` - optional:
+   * `radius` - stop within this distance of the goal (default: the personality's `stopRadius`)
+   * `timeout` - ms (default `60000`)
+   * `faceAt` - Vec3 to look at once arrived (an entity's eyes, a block); the Promise resolves after the look settles
+
+### human.lookAt(point, options)
+Turns the head to `point` after a reaction delay and resolves once it has settled.
+ * `options.settleMs` - how long the head must be still (default `300`)
+
+### human.stop()
+Aborts the walk in progress (its Promise rejects with `stopped`) and releases the head.
+
+### human.active
+Set to `false` to suspend the controller without dropping its state.
+
+### human.route
+Waypoints of the walk in progress, or of the last one.
+
+### human.personality
+The traits in use: `basePitch` (radians, positive looks down), `turnTime` (gesture duration scale, 1 = median), `sprints`, `sprintDelay` (s), `jumpRate` (sprint-jumps/s, 0 = never), `lookAhead` (blocks), `stopRadius` (blocks), `reaction` (s), `glanceRate` (glances/s, 0 = never), `strafe` (probability), `deadband` (radians of steering error tolerated before the next correction).
+
 # Movement class
 This class configures how pathfinder plans its paths. It configures things like block breaking or different costs for moves. This class can be extended to add or change how pathfinder calculates its moves.
 

--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,7 @@ await human.walkTo(new Vec3(10.5, 64, -20.5), { faceAt: npc.position.offset(0, 1
  * `Returns` - a `Human`
 
 ### human.walkTo(goal, options)
-Walks to `goal` (a Vec3 at feet level) and returns a Promise that resolves once the bot has come to a stop there. Rejects with `no path`, `stuck`, `walk timed out`, `superseded` (a newer `walkTo` was issued) or `stopped`.
+Walks to `goal` (a Vec3 at feet level) and returns a Promise that resolves once the bot has come to a stop there. The goal is `goal`'s block column within a block of its level. Planning runs in tick-sized slices and never blocks the event loop for longer than one. A goal the search cannot reach is walked as far as the closest reachable point before the Promise rejects with `no path`. Also rejects with `stuck`, `walk timed out`, `superseded` (a newer `walkTo` was issued) or `stopped`.
  * `options` - optional:
    * `radius` - stop within this distance of the goal (default: the personality's `stopRadius`)
    * `timeout` - ms (default `60000`)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1294,4 +1294,16 @@ describe('human walker', function () {
     await assert.rejects(first, /superseded/)
     await second
   })
+
+  it('walkTo walks to the closest reachable point before rejecting with no path', async function () {
+    this.timeout(20000)
+    this.slow(8000)
+    bot.entity.position = spawnPos.clone()
+    await once(bot, 'physicsTick')
+    // Beyond the loaded chunk: the search ends without reaching it.
+    await assert.rejects(human.walkTo(spawnPos.offset(0, 0, 60)), /no path/)
+    const p = bot.entity.position
+    assert.ok(p.z > spawnPos.z + 3, `stopped at ${p}, did not head for the goal`)
+    assert.ok(human.route.length >= 2 && !human.route[human.route.length - 1].equals(spawnPos.offset(0, 0, 60)), 'route must end at the closest node, not the goal')
+  })
 })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1295,6 +1295,15 @@ describe('human walker', function () {
     await second
   })
 
+  it('walkTo resolves when the bot already stands in the goal block', async function () {
+    this.timeout(15000)
+    bot.entity.position = spawnPos.clone()
+    await once(bot, 'physicsTick')
+    await human.walkTo(spawnPos.offset(0.2, 0, -0.2))
+    const p = bot.entity.position
+    assert.ok(Math.hypot(p.x - spawnPos.x, p.z - spawnPos.z) < 1, `walked off to ${p}`)
+  })
+
   it('walkTo walks to the closest reachable point before rejecting with no path', async function () {
     this.timeout(20000)
     this.slow(8000)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1307,6 +1307,36 @@ describe('human walker', function () {
     assert.ok(yawErr < 2 * Math.PI / 180, `facing ${yawErr * 180 / Math.PI} deg off faceAt`)
   })
 
+  it('a superseded walkTo stops searching instead of running out its think timeout', async function () {
+    this.timeout(15000)
+    bot.entity.position = spawnPos.clone()
+    await once(bot, 'physicsTick')
+    const realGetPath = bot.pathfinder.getPathFromTo.bind(bot.pathfinder)
+    let slices = 0
+    let stubbed = false
+    // A search that only converges after many slices, standing in for one that runs out its think timeout.
+    const SLICES = 400
+    bot.pathfinder.getPathFromTo = (...args) => {
+      if (stubbed) return realGetPath(...args)
+      stubbed = true
+      return {
+        next: () => {
+          slices++
+          const result = { status: slices < SLICES ? 'partial' : 'timeout', path: [] }
+          return { done: slices >= SLICES, value: { result } }
+        }
+      }
+    }
+    const first = human.walkTo(spawnPos.offset(0, 0, 6))
+    await new Promise(resolve => setImmediate(resolve))
+    const second = human.walkTo(spawnPos.offset(1, 0, 0))
+    const atSupersede = slices
+    await assert.rejects(first, /superseded/)
+    await second
+    bot.pathfinder.getPathFromTo = realGetPath
+    assert.ok(slices - atSupersede <= 1, `superseded search ran ${slices - atSupersede} more slices`)
+  })
+
   it('walkTo walks to the closest reachable point before rejecting with no path', async function () {
     this.timeout(20000)
     this.slow(8000)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1299,9 +1299,12 @@ describe('human walker', function () {
     this.timeout(15000)
     bot.entity.position = spawnPos.clone()
     await once(bot, 'physicsTick')
-    await human.walkTo(spawnPos.offset(0.2, 0, -0.2))
+    await human.walkTo(spawnPos.offset(0.2, 0, -0.2), { faceAt })
     const p = bot.entity.position
     assert.ok(Math.hypot(p.x - spawnPos.x, p.z - spawnPos.z) < 1, `walked off to ${p}`)
+    const wantYaw = Math.atan2(-(faceAt.x - p.x), -(faceAt.z - p.z))
+    const yawErr = Math.abs(Math.atan2(Math.sin(wantYaw - bot.entity.yaw), Math.cos(wantYaw - bot.entity.yaw)))
+    assert.ok(yawErr < 2 * Math.PI / 180, `facing ${yawErr * 180 / Math.PI} deg off faceAt`)
   })
 
   it('walkTo walks to the closest reachable point before rejecting with no path', async function () {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1258,7 +1258,9 @@ describe('human walker', function () {
     a.active = false
     b.active = false
     assert.deepStrictEqual(a.personality, b.personality)
-    assert.strictEqual(createHuman(bot, { seed: 1, personality: { sprints: false } }).personality.sprints, false)
+    const c = createHuman(bot, { seed: 1, personality: { sprints: false } })
+    c.active = false
+    assert.strictEqual(c.personality.sprints, false)
   })
 
   it('walkTo stops at the goal facing faceAt, on the sensitivity grid', async function () {
@@ -1284,6 +1286,26 @@ describe('human walker', function () {
     for (const [y, pch] of rotations) {
       for (const a of [y, pch]) assert.ok(Math.abs(a / sens - Math.round(a / sens)) < 1e-6, `rotation ${a} off the sensitivity grid`)
     }
+  })
+
+  it('a rotation forced after the walk stands', async function () {
+    this.timeout(15000)
+    bot.entity.position = spawnPos.clone()
+    await human.walkTo(goal)
+    bot.entity.yaw = 1.25
+    bot.entity.pitch = -0.5
+    bot.emit('forcedMove')
+    await bot.waitForTicks(10)
+    assert.strictEqual(bot.entity.yaw, 1.25, 'yaw was pulled back after the walk')
+    assert.strictEqual(bot.entity.pitch, -0.5, 'pitch was pulled back after the walk')
+
+    await human.lookAt(faceAt)
+    bot.entity.yaw = -0.75
+    bot.entity.pitch = 0.25
+    bot.emit('forcedMove')
+    await bot.waitForTicks(10)
+    assert.strictEqual(bot.entity.yaw, -0.75, 'yaw was pulled back after lookAt')
+    assert.strictEqual(bot.entity.pitch, 0.25, 'pitch was pulled back after lookAt')
   })
 
   it('walkTo rejects when superseded', async function () {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 const mineflayer = require('mineflayer')
-const { goals, pathfinder, Movements } = require('mineflayer-pathfinder')
+const { goals, pathfinder, Movements, createHuman } = require('mineflayer-pathfinder')
 const { Vec3 } = require('vec3')
 const mc = require('minecraft-protocol')
 const assert = require('assert')
@@ -1220,5 +1220,78 @@ describe('pathfinder entity avoidance test', function () {
       assert.ok(path.length === 6, `Generated path length wrong (${path.length} === 6)`)
       assert.ok(leftBranch === true, `Generated path did not follow Left Branch [Left Branch: ${leftBranch}, Right Branch: ${rightBranch}, Forward Branch: ${forwardBranch}, Backward Branch: ${backwardBranch}]`)
     })
+  })
+})
+
+describe('human walker', function () {
+  const spawnPos = new Vec3(8.5, 1, 8.5) // Center of the chunk & center of the block
+  const goal = new Vec3(3.5, 1, 12.5)
+  const faceAt = new Vec3(3.5, 2.6, 2.5)
+
+  /** @type { import('mineflayer').Bot & { pathfinder: import('mineflayer-pathfinder').Pathfinder }} */
+  let bot
+  /** @type { import('minecraft-protocol').Server } */
+  let server
+  /** @type { import('mineflayer-pathfinder').Human } */
+  let human
+
+  before(async () => {
+    const chunk = flatMap(Version)
+    server = await newServer(server, chunk, spawnPos, Version, true)
+    bot = mineflayer.createBot({
+      username: 'player',
+      version: Version,
+      port: ServerPort
+    })
+    await once(bot, 'chunkColumnLoad')
+    bot.loadPlugin(pathfinder)
+    human = createHuman(bot, { seed: 7 })
+  })
+  after(() => {
+    human.active = false
+    server.close()
+  })
+
+  it('seed reproduces a personality', function () {
+    const a = createHuman(bot, { seed: 123 })
+    const b = createHuman(bot, { seed: 123 })
+    a.active = false
+    b.active = false
+    assert.deepStrictEqual(a.personality, b.personality)
+    assert.strictEqual(createHuman(bot, { seed: 1, personality: { sprints: false } }).personality.sprints, false)
+  })
+
+  it('walkTo stops at the goal facing faceAt, on the sensitivity grid', async function () {
+    this.timeout(15000)
+    this.slow(6000)
+    const sens = 0.15 * Math.PI / 180
+    const rotations = []
+    const onMove = () => rotations.push([bot.entity.yaw, bot.entity.pitch])
+    bot.on('move', onMove)
+    await human.walkTo(goal, { faceAt })
+    bot.off('move', onMove)
+
+    const p = bot.entity.position
+    assert.ok(Math.hypot(p.x - goal.x, p.z - goal.z) < 1, `stopped ${p} away from ${goal}`)
+    assert.ok(Math.hypot(bot.entity.velocity.x, bot.entity.velocity.z) < 0.02, 'still moving')
+    assert.ok(human.route.length >= 2 && human.route[human.route.length - 1].equals(goal))
+
+    const wantYaw = Math.atan2(-(faceAt.x - p.x), -(faceAt.z - p.z))
+    const yawErr = Math.abs(Math.atan2(Math.sin(wantYaw - bot.entity.yaw), Math.cos(wantYaw - bot.entity.yaw)))
+    assert.ok(yawErr < 2 * Math.PI / 180, `facing ${yawErr * 180 / Math.PI}° off faceAt`)
+    assert.ok(bot.entity.pitch > 0, 'faceAt is above eye level, pitch should look up')
+
+    for (const [y, pch] of rotations) {
+      for (const a of [y, pch]) assert.ok(Math.abs(a / sens - Math.round(a / sens)) < 1e-6, `rotation ${a} off the sensitivity grid`)
+    }
+  })
+
+  it('walkTo rejects when superseded', async function () {
+    this.timeout(15000)
+    bot.entity.position = spawnPos.clone()
+    const first = human.walkTo(goal)
+    const second = human.walkTo(spawnPos.offset(2, 0, 0))
+    await assert.rejects(first, /superseded/)
+    await second
   })
 })


### PR DESCRIPTION
Adds \`createHuman(bot, options)\`, exported next to \`Movements\` and \`goals\`. It uses the pathfinder only to plan; a per-tick controller then walks the route the way a player does rather than the way the executor does:

- waypoints are string-pulled, then followed by pure pursuit with a 2–3 block look-ahead, so corners become curves and the bot never snaps to block centres
- the head moves only in discrete mouse gestures: a minimum-jerk sweep whose duration grows with the square root of the angle, landing slightly off its mark, on the 0.15° sensitivity grid (the same grid \`bot.look\` already rounds to); between gestures no rotation is sent (a steering dead band of 4–12° while walking, precise aiming for a look order)
- sprint starts 0–0.8 s after the first step, sprint-jumps come at a personal rate, and the walk coasts to a stop instead of braking on the goal, then faces \`faceAt\` (an NPC's eyes, a block)
- reaction delay, base pitch, occasional glances and strafing are per-bot personality traits; \`createHuman(bot, { seed })\` reproduces one

```js
const { pathfinder, createHuman } = require('mineflayer-pathfinder')
bot.loadPlugin(pathfinder)
const human = createHuman(bot, { seed: 42 })
await human.walkTo(target.position, { faceAt: target.position.offset(0, 1.62, 0) })
```

It walks, steps up single blocks and drops down; it does not dig, place, swim or parkour, and its default \`Movements\` disables those (a caller can pass its own via \`options.movements\`). The existing executor is untouched, so this is purely additive and opt-in.

Calibration numbers come from 48 players recorded walking from a lobby spawn to a row of NPCs on a public 1.21.4 server; the distributions are listed at the top of \`lib/human.js\`. On the same route the bot's 100 ms head-turn distribution overlaps the players' and about 70% of its moving samples carry no rotation, as theirs do. Tested live on that server (four legs of 6–9 s each, ending 0.3 blocks from the goal facing the NPC) and ported here from https://github.com/u9g/bot-harness/pull/5.

Includes readme docs, types in \`index.d.ts\`, \`examples/human.js\`, and tests on the fake flat-map server (walk arrives, stops, faces the target with every rotation on the sensitivity grid; seed reproducibility; superseding a walk rejects the first one). \`npm test\` passes (53 tests).