### PR TITLE
fix: goto rejects an unreachable goal instead of resolving, and stop() no longer latches while idle

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,9 @@ function inject (bot) {
   }
 
   bot.pathfinder.stop = () => {
+    // Nothing is running, so there is nothing to stop; the flag would otherwise survive until the
+    // next goal and stop that one instead.
+    if (!stateGoal && path.length === 0) return
     stopPathing = true
   }
 

--- a/lib/goto.js
+++ b/lib/goto.js
@@ -20,12 +20,14 @@ function goto (bot, goal) {
     }
 
     function noPathListener (results) {
-      if (results.path.length === 0) {
-        cleanup()
-      } else if (results.status === 'noPath') {
+      // A search that fails or is still slicing reconstructs its best node, which is the start node
+      // and so an empty path. Only a 'success' with nothing to walk means the goal is already met.
+      if (results.status === 'noPath') {
         cleanup(error('NoPath', 'No path to the goal!'))
       } else if (results.status === 'timeout') {
         cleanup(error('Timeout', 'Took to long to decide path to goal!'))
+      } else if (results.status === 'success' && results.path.length === 0) {
+        cleanup()
       }
     }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -422,6 +422,32 @@ describe('pathfinder util functions', function () {
       await bot.pathfinder.goto(new goals.GoalGetToBlock(targetBlock.x, targetBlock.y, targetBlock.z))
     })
 
+    it('Goto rejects when there is no path to the goal', async function () {
+      this.timeout(10000)
+      const strict = new Movements(bot, mcData)
+      strict.canDig = false
+      strict.allow1by1towers = false
+      strict.scafoldingBlocks = []
+      bot.pathfinder.setMovements(strict)
+      try {
+        // Five blocks straight up with nothing to build or climb on: every neighbour is further from
+        // the goal than the start, so A* gives back 'noPath' with an empty path.
+        await assert.rejects(
+          bot.pathfinder.goto(new goals.GoalBlock(Math.floor(spawnPos.x), spawnPos.y + 5, Math.floor(spawnPos.z))),
+          { name: 'NoPath' }
+        )
+      } finally {
+        bot.pathfinder.setMovements(new Movements(bot, mcData))
+      }
+    })
+
+    it('stop() while the bot is not pathing does not abort the next goal', async function () {
+      this.timeout(3000)
+      this.slow(1500)
+      bot.pathfinder.stop()
+      await bot.pathfinder.goto(new goals.GoalGetToBlock(targetBlock.x, targetBlock.y, targetBlock.z))
+    })
+
     it('isMoving', function (done) {
       bot.pathfinder.setGoal(new goals.GoalGetToBlock(targetBlock.x, targetBlock.y, targetBlock.z))
       const foo = () => {


### PR DESCRIPTION
Two bugs found while driving a bot around a server island where the pathfinder is regularly boxed in.

**`goto` resolves when there is no path.** `AStar.makeResult` reconstructs `this.bestNode`, and when the search never improves on the start node that reconstruction is `[]` (`reconstructPath` walks `node.parent`). `noPathListener` tested the length before the status:

```js
if (results.path.length === 0) {
  cleanup()                                   // resolve
} else if (results.status === 'noPath') {
  cleanup(error('NoPath', 'No path to the goal!'))
```

so a goal the bot cannot reach resolved as if it had been reached, and `await bot.pathfinder.goto(goal)` returned with the bot standing still. The same branch also swallowed `partial` results — every slice of a search that has not finished yet reconstructs the same best node — which is why the failure only shows up sometimes: if the first slice runs out its `tickTimeout` the promise resolves before the search ever concludes. Now only `success` with an empty path resolves (already at the goal); `noPath` and `timeout` reject as documented and `partial` keeps waiting.

**`bot.pathfinder.stop()` latches when nothing is running.** `stopPathing` is only cleared inside `stop()`, which is reached from `fullStop()` or from arriving at a node. Calling `pathfinder.stop()` with no goal and no path leaves the flag set until the *next* `setGoal`, whose `resetPath` -> `fullStop` then stops it immediately and rejects the new `goto` with `PathStopped`. The readme describes `stop()` as stopping at the next node of the current path, so with no path there is nothing to stop.

Two tests in `test/internalTest.js`; both fail on master (`Missing expected rejection (NoPath)` and `PathStopped: Path was stopped before it could be completed!`) and the file's other 57 pass unchanged.