### PR TITLE
createHuman: a walk that stops under an unreachable goal rejects instead of resolving

### DIFF
--- a/lib/human.js
+++ b/lib/human.js
@@ -289,7 +289,10 @@ function createHuman (bot, opts = {}) {
       bot.setControlState('right', false)
       bot.setControlState('sprint', false)
       if (speed < 0.02) {
-        if (w.complete || horiz(w.goal.minus(pos)) <= w.radius + 1) finishWalk(w)
+        // Proximity counts only at the goal's level: a route that ends under an unreachable ledge
+        // stops in the goal's column many blocks below it.
+        const atGoal = horiz(w.goal.minus(pos)) <= w.radius + 1 && Math.abs(w.goal.y - pos.y) <= 1.5
+        if (w.complete || atGoal) finishWalk(w)
         else failWalk(w, new Error(`no path to ${w.goal}`))
       }
       return

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1359,6 +1359,19 @@ describe('human walker', function () {
     assert.ok(slices - atSupersede <= 1, `superseded search ran ${slices - atSupersede} more slices`)
   })
 
+  it('walkTo rejects with no path when the route ends under an unreachable goal', async function () {
+    this.timeout(20000)
+    this.slow(8000)
+    bot.entity.position = spawnPos.clone()
+    await once(bot, 'physicsTick')
+    // The goal's column is a short walk away, but its level is 20 blocks up in the air.
+    const above = goal.offset(0, 20, 0)
+    await assert.rejects(human.walkTo(above), /no path/)
+    const p = bot.entity.position
+    assert.ok(Math.hypot(p.x - above.x, p.z - above.z) < 1.5, `stopped at ${p}, did not walk under the goal`)
+    assert.ok(Math.hypot(bot.entity.velocity.x, bot.entity.velocity.z) < 0.02, 'still moving')
+  })
+
   it('walkTo walks to the closest reachable point before rejecting with no path', async function () {
     this.timeout(20000)
     this.slow(8000)


### PR DESCRIPTION
When the search cannot reach the goal, the walk follows the route to the closest reachable node and then decides between success and \`no path\` by proximity. That check was horizontal only, so a goal straight above the closest reachable point (an NPC row on a ledge above a lobby plaza) resolved successfully the moment the bot coasted to a stop under it. Seen live: \`walkTo((-2, 108, 5))\` from \`(0, 84, -17)\` resolved at \`(-2, 87, 5)\`.

Proximity now also requires the goal to be within 1.5 blocks vertically, matching the planner's goal (the goal's column within a block of its level). The bot still walks to the closest reachable point first, and the promise rejects with \`no path\` as documented.

Test: \`walkTo rejects with no path when the route ends under an unreachable goal\` walks to a goal 20 blocks above the flat test map; on master it resolves.

Reported in u9g/bot-harness#29.