### PR TITLE
createHuman: walkTo and lookAt say so when physics is disabled

### DIFF
--- a/lib/human.js
+++ b/lib/human.js
@@ -427,7 +427,17 @@ function createHuman (bot, opts = {}) {
 
   let planSeq = 0
 
+  // Everything this controller does lands on a physics tick: the walk driver runs on physicsTick
+  // and the head is aimed there too. With physics off the bot cannot be driven at all, so a walkTo
+  // would stand still for its whole timeout and a lookAt would never settle. Callers freeze the bot
+  // for good reasons - a server that freezes players in a pre-game lobby, a setback guard - and want
+  // to hear about it now, not in a minute.
+  function requirePhysics (what) {
+    if (bot.physicsEnabled === false) throw new Error(`${what} needs physics: bot.physicsEnabled is false`)
+  }
+
   async function walkTo (goal, o = {}) {
+    requirePhysics('walkTo')
     if (walk) failWalk(walk, new Error('superseded'))
     const seq = ++planSeq
     const plan = await planRoute(goal, () => seq === planSeq)
@@ -452,7 +462,8 @@ function createHuman (bot, opts = {}) {
         replans: 0,
         resolve,
         reject,
-        timer: setTimeout(() => failWalk(w, new Error('walk timed out')), o.timeout ?? 60000)
+        // Physics can also be turned off mid-walk, which looks exactly like a walk that got stuck.
+        timer: setTimeout(() => failWalk(w, new Error(bot.physicsEnabled === false ? 'walk timed out: physics was disabled mid-walk' : 'walk timed out')), o.timeout ?? 60000)
       }
       walk = w
       human.route = route
@@ -460,6 +471,7 @@ function createHuman (bot, opts = {}) {
   }
 
   async function lookAt (point, o = {}) {
+    requirePhysics('lookAt')
     await new Promise(resolve => setTimeout(resolve, personality.reaction * 1000 * (0.5 + r())))
     targetYaw = yawTo(bot.entity.position, point)
     targetPitch = pitchTo(bot.entity.position, point)

--- a/readme.md
+++ b/readme.md
@@ -164,14 +164,14 @@ await human.walkTo(new Vec3(10.5, 64, -20.5), { faceAt: npc.position.offset(0, 1
  * `Returns` - a `Human`
 
 ### human.walkTo(goal, options)
-Walks to `goal` (a Vec3 at feet level) and returns a Promise that resolves once the bot has come to a stop there. The goal is `goal`'s block column within a block of its level. Planning runs in tick-sized slices and never blocks the event loop for longer than one. A goal the search cannot reach is walked as far as the closest reachable point before the Promise rejects with `no path`. Also rejects with `stuck`, `walk timed out`, `superseded` (a newer `walkTo` was issued) or `stopped`.
+Walks to `goal` (a Vec3 at feet level) and returns a Promise that resolves once the bot has come to a stop there. The goal is `goal`'s block column within a block of its level. Planning runs in tick-sized slices and never blocks the event loop for longer than one. A goal the search cannot reach is walked as far as the closest reachable point before the Promise rejects with `no path`. Also rejects with `stuck`, `walk timed out`, `superseded` (a newer `walkTo` was issued) or `stopped`. The controller drives the bot from physics ticks, so with `bot.physicsEnabled` set to `false` it cannot move it at all and rejects straight away instead of standing still until the timeout.
  * `options` - optional:
    * `radius` - stop within this distance of the goal (default: the personality's `stopRadius`)
    * `timeout` - ms (default `60000`)
    * `faceAt` - Vec3 to look at once arrived (an entity's eyes, a block); the Promise resolves after the look settles
 
 ### human.lookAt(point, options)
-Turns the head to `point` after a reaction delay and resolves once it has settled.
+Turns the head to `point` after a reaction delay and resolves once it has settled. Rejects straight away when `bot.physicsEnabled` is `false`, because the head only moves on a physics tick.
  * `options.settleMs` - how long the head must be still (default `300`)
 
 ### human.stop()

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1370,4 +1370,31 @@ describe('human walker', function () {
     assert.ok(p.z > spawnPos.z + 3, `stopped at ${p}, did not head for the goal`)
     assert.ok(human.route.length >= 2 && !human.route[human.route.length - 1].equals(spawnPos.offset(0, 0, 60)), 'route must end at the closest node, not the goal')
   })
+
+  it('walkTo and lookAt reject at once while physics is disabled', async function () {
+    this.timeout(20000)
+    this.slow(8000)
+    bot.entity.position = spawnPos.clone()
+    await once(bot, 'physicsTick')
+    const from = bot.entity.position.clone()
+    const yaw = bot.entity.yaw
+    bot.physicsEnabled = false
+    const t0 = Date.now()
+    try {
+      await assert.rejects(human.walkTo(goal, { timeout: 60000 }), /physicsEnabled is false/)
+      await assert.rejects(human.lookAt(faceAt), /physicsEnabled is false/)
+    } finally {
+      bot.physicsEnabled = true
+    }
+    // The point of the guard: the caller hears back now, not when the walk timeout expires.
+    assert.ok(Date.now() - t0 < 2000, `took ${Date.now() - t0} ms to report physics was off`)
+    assert.ok(bot.entity.position.distanceTo(from) < 0.01, `moved to ${bot.entity.position} with physics disabled`)
+    assert.strictEqual(bot.entity.yaw, yaw, 'turned the head with physics disabled')
+
+    // ...and the controller is still usable once physics comes back.
+    await once(bot, 'physicsTick')
+    await human.walkTo(goal)
+    const p = bot.entity.position
+    assert.ok(Math.hypot(p.x - goal.x, p.z - goal.z) < 1, `stopped ${p} away from ${goal}`)
+  })
 })


### PR DESCRIPTION
`createHuman`'s controller drives the bot from physics ticks: `tickWalk` runs on `physicsTick`,
and the head is aimed there too. With `bot.physicsEnabled = false` nothing it does reaches the
server, and both public calls fail in the least informative way possible:

- **`walkTo`** stands still for its entire timeout and then rejects with `walk timed out`, which
  reads as "the route was bad" or "something blocked the bot". Default timeout is 60 s.
- **`lookAt`** never settles at all. `settled()` only resolves from a `physicsTick`, so with no
  ticks the promise is simply never answered — the caller is parked for good.

Callers turn physics off for good reasons, and the failure never points at them. Mine was a
minigame server that freezes players in its pre-game lobby plus a setback guard riding out a
rubber-band storm; a control loop calling `walkTo` through the freeze went 90 s without moving
and reported a timeout, and an in-flight `lookAt` left a loop parked until the process was
restarted. The freeze is the last thing you suspect when the error says "timed out".

This rejects up front instead:

```js
function requirePhysics (what) {
  if (bot.physicsEnabled === false) throw new Error(`${what} needs physics: bot.physicsEnabled is false`)
}
```

called from `walkTo` and `lookAt`. Physics can also be turned off *during* a walk, which looks
exactly like a walk that got stuck, so the timeout error names it when that is what happened:
`walk timed out: physics was disabled mid-walk`.

Nothing changes for a bot with physics on — the guard reads a flag and returns.

### Test

`test/internalTest.js`, in the existing `human walker` block: with physics off, `walkTo` and
`lookAt` both reject inside 2 s, the bot has not moved and its head has not turned, and the
controller still walks normally once physics comes back.

Without the fix the test hangs and mocha kills it at the suite timeout — which is the bug:

```
  1) human walker
       walkTo and lookAt reject at once while physics is disabled:
     Error: Timeout of 20000ms exceeded.
```

With it, the whole block passes:

```
  human walker
    ✔ seed reproduces a personality
    ✔ walkTo stops at the goal facing faceAt, on the sensitivity grid
    ✔ a rotation forced after the walk stands (3815ms)
    ✔ walkTo rejects when superseded (958ms)
    ✔ walkTo resolves when the bot already stands in the goal block (1206ms)
    ✔ a superseded walkTo stops searching instead of running out its think timeout (952ms)
    ✔ walkTo walks to the closest reachable point before rejecting with no path
    ✔ walkTo and lookAt reject at once while physics is disabled

  8 passing (14s)
```

`readme.md` gets the two sentences that say so.
